### PR TITLE
Balboa Agent Debian Package

### DIFF
--- a/balboa-agent/README.md
+++ b/balboa-agent/README.md
@@ -42,6 +42,21 @@ Others: TODO
 * _agent_ : Standalone process that both consumes and emits metrics.
 * _amq_ : Active MQ
 
+### Build
+
+Balboa Agent can be built as a typical assembly jar
+
+```
+sbt balboa-agent/assembly
+```
+
+This project also incorporates [Sbt Native Packager](http://www.scala-sbt.org/sbt-native-packager/). And builds a simple debian
+ package that wraps an assembly jar.  This assembly jar can be found at the debian install root /balboa-agent/bin/balboa-agent-assembly.jar.
+
+```
+sbt balboa-agent/debian:packageBin
+```
+
 ### Configuration
 
 Configuration is done through Balboa Configuration properties or via the command line.  Command line arguments overwrite

--- a/build.sbt
+++ b/build.sbt
@@ -1,1 +1,10 @@
 scalaVersion := "2.10.4"
+
+maintainer := "Socrata SUM Team, sum-team-l@socrata.com"
+
+packageSummary := "Balboa"
+
+packageDescription :=
+  """
+    |Internal Metrics System.
+  """.stripMargin

--- a/project/Balboa.scala
+++ b/project/Balboa.scala
@@ -1,6 +1,7 @@
 import com.socrata.eu.diversit.sbt.plugin.WebDavPlugin.WebDav
+import com.typesafe.sbt.packager.debian.JDebPackaging
+import com.typesafe.sbt.packager.universal.UniversalPlugin
 import sbt._
-import sbtdocker.DockerPlugin
 
 object Balboa extends Build {
 
@@ -28,6 +29,8 @@ object Balboa extends Build {
   lazy val balboaAdmin = project("balboa-admin", None, BalboaAdmin, balboaCore)
 
   lazy val balboaAgent = project("balboa-agent", None, BalboaAgent, balboaClientJMS, balboaCommon)
+    .enablePlugins(UniversalPlugin)
+    .enablePlugins(JDebPackaging)
 
   lazy val balboaClientCore = project("balboa-client-core", Some("balboa-client"), BalboaClient,
     balboaCommon % "test->test;compile->compile")
@@ -45,7 +48,6 @@ object Balboa extends Build {
 
   lazy val balboaKafkaService = project("balboa-kafka-service", Some("balboa-service-kafka"),
     BalboaKafka, balboaServiceCore, balboaKafkaClient % "test->test;compile->compile")
-    .enablePlugins(DockerPlugin)
 
   lazy val balboaClientDispatcher = project("balboa-dispatcher-client", Some("balboa-client-dispatcher"),
     BalboaClientDispatcher,

--- a/project/BalboaAgent.scala
+++ b/project/BalboaAgent.scala
@@ -2,12 +2,21 @@ import Dependencies._
 import sbt.Keys._
 import sbt._
 import sbtassembly.Plugin.AssemblyKeys._
-import sbtassembly.Plugin.{MergeStrategy, PathList}
+import com.typesafe.sbt.SbtNativePackager._
 
 object BalboaAgent {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings(assembly = true) ++ Seq(
     mainClass in assembly := Some("com.socrata.balboa.agent.BalboaAgent"),
-    libraryDependencies <++= scalaVersion { libraries(_) }
+    libraryDependencies <++= scalaVersion { libraries(_) },
+    jarName in assembly := s"${name.value}-assembly.jar",
+    mappings in Universal :=  {
+      val universalMappings = (mappings in Universal).value
+      val fatJar = (assembly in Compile).value
+      val filtered = universalMappings filter {
+        case (file, name) =>  ! name.endsWith(".jar")
+      }
+      filtered :+ (fatJar -> ("bin/" + fatJar.getName))
+    }
   )
 
   def libraries(implicit scalaVersion: String) = BalboaCommon.libraries ++ Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,5 @@ addSbtPlugin("com.socrata" % "socrata-cloudbees-sbt" % "1.3.4")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
-// TODO Try this Docker plug in later.
-// Why not have SBT call docker cli to build image and post to registry?
-// Another process that I feel should be more automated but it is sadly not.
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.0.0")
+// Sbt Native Packager
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.2")


### PR DESCRIPTION
Using SBT-Native-Packager, Balboa Agent assembly jars can now be packaged within .deb.  This allows us to publish artifiacts to S3 and utilize existing Socrata Deployment pipeline.