### PR TITLE
Removed package dependency on openjdk-headless-jre.

### DIFF
--- a/project/BalboaAgent.scala
+++ b/project/BalboaAgent.scala
@@ -19,7 +19,8 @@ object BalboaAgent {
       }
       filtered :+ (fatJar -> ("bin/" + fatJar.getName))
     },
-    debianPackageDependencies in debian.DebianPlugin.autoImport.Debian := Seq("openjdk-7-jre-headless")
+    debianPackageDependencies in debian.DebianPlugin.autoImport.Debian := Seq(),
+    debianPackageRecommends in debian.DebianPlugin.autoImport.Debian := Seq("openjdk-7-jre-headless")
   )
 
   def libraries(implicit scalaVersion: String) = BalboaCommon.libraries ++ Seq(


### PR DESCRIPTION
This introduces to string of a dependency.  Debian also does not manage java dependencies very well either.  Therefore we decided to move the java 7 dependency into the debian package recommendation list.