### PR TITLE
Use Travis container infrastructure with caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ scala:
 jdk:
   - oraclejdk7
   - openjdk7
+sudo: false
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/


### PR DESCRIPTION
Travis appears to be [encouraging use of their new container-based infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/), which also allows caching across builds.

I was hoping to see build time improvements, but unfortunately there wasn't any significant change, even on a [rebuild using the cache](https://travis-ci.org/socrata-platform/balboa/builds/73297994).