### PR TITLE
Balboa Agent Distribution and Metrics updates

### DIFF
--- a/balboa-agent/src/main/resources/config/config.properties
+++ b/balboa-agent/src/main/resources/config/config.properties
@@ -5,5 +5,5 @@ balboa.agent.data.dir = /tmp
 balboa.agent.sleeptime = 10000
 
 # ActiveMQ Properties
-balboa.jms.activemq.server = tcp://localhost:61616
-balboa.jms.activemq.queue = "test-queue"
+balboa.jms.activemq.server = "failover:tcp://120.0.0.1:61616"
+balboa.jms.activemq.queue = "Metrics2012"

--- a/balboa-agent/src/main/resources/log4j.properties
+++ b/balboa-agent/src/main/resources/log4j.properties
@@ -1,5 +1,12 @@
-log4j.rootLogger=INFO,stdout
+log4j.rootLogger=INFO,stdout,rollingFile
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %d{MM-dd-yyyy HH:mm:ss} %c %M - %m%n
-log4j.category.org.apache=INFO,stdout
+
+# Example Rolling Log File Appender.
+log4j.appender.rollingFile=org.apache.log4j.RollingFileAppender
+log4j.appender.rollingFile.File=/tmp/agent.log
+log4j.appender.rollingFile.MaxFileSize=100MB
+log4j.appender.rollingFile.MaxBackupIndex=0
+log4j.appender.rollingFile.layout=org.apache.log4j.PatternLayout
+log4j.appender.rollingFile.layout.ConversionPattern=[%p] %d{MM-dd-yyyy HH:mm:ss} %c %M - %m%n


### PR DESCRIPTION
* Balboa root project now aggregates Balboa Agent subproject
* Updated Balboa to latest Scala 2.10 patch
* Update sat-native-packager 1.0.2 -> 1.0.4
* Introduced drop wizard metrics for Balboa Agent
* Balboa Agent now utilizes SBT Native Packager JavaAppArchetype to manage distribution structure
* Balboa Agent now utilized Debian and Docker distribution.
* Metric Consumer tracks per instance metrics
* Balboa Agent uses Socrata/java base image and runs as socrata user.