### PR TITLE
EN-2457: Publish balboa-client with Scala 2.11

### DIFF
--- a/balboa-client-jms/src/main/scala/com/socrata/balboa/impl/AsyncActiveMQQueue.scala
+++ b/balboa-client-jms/src/main/scala/com/socrata/balboa/impl/AsyncActiveMQQueue.scala
@@ -10,7 +10,7 @@ import org.apache.activemq.{ActiveMQConnection, ActiveMQConnectionFactory}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.future
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 /**
@@ -41,7 +41,7 @@ class AsyncActiveMQQueue(connectionUri: String, queueName: String) extends Abstr
   def start() {
     if (!started) {
       started = true
-      future { activeMQFactory.createConnection() } onComplete {
+      Future { activeMQFactory.createConnection() } onComplete {
         case Success(conn) =>
           connection = Some({
             val activeMQConn = conn.asInstanceOf[ActiveMQConnection]

--- a/balboa-client/src/main/scala/com/socrata/metrics/MetricQueue.scala
+++ b/balboa-client/src/main/scala/com/socrata/metrics/MetricQueue.scala
@@ -177,20 +177,16 @@ trait SocrataMetricQueue extends MetricQueue {
   }
 
   def logDatasetReferrer(referrer:ReferrerUri, viewUid:ViewUid) {
-    try {
-      create(MetricIdParts(Fluff("referrer-hosts-"), viewUid), MetricIdParts(Fluff("referrer-"), Host(referrer.getHost())), 1)
-      create(MetricIdParts(Fluff("referrer-paths-"), viewUid, Fluff("-"), Host(referrer.getHost())), MetricIdParts(Fluff("path-"), Path(referrer.getPath)), 1)
-    }
+    create(MetricIdParts(Fluff("referrer-hosts-"), viewUid), MetricIdParts(Fluff("referrer-"), Host(referrer.getHost())), 1)
+    create(MetricIdParts(Fluff("referrer-paths-"), viewUid, Fluff("-"), Host(referrer.getHost())), MetricIdParts(Fluff("path-"), Path(referrer.getPath)), 1)
   }
 
   def logPublish(referrer:ReferrerUri, viewUid:ViewUid, domainId:DomainId) {
-    try {
-      create(MetricIdParts(Fluff("publishes-uids-"), domainId),MetricIdParts(Fluff("uid-"), viewUid), 1)
-      create(MetricIdParts(Fluff("publishes-hosts-"), viewUid),MetricIdParts(Fluff("referrer-"), Host(referrer.getHost())), 1)
-      create(MetricIdParts(Fluff("publishes-paths-"), viewUid, Fluff("-"), Host(referrer.getHost())),MetricIdParts(Fluff("path-"), Path(referrer.getPath)), 1)
-      create(MetricIdParts(Fluff("publishes-hosts-"), domainId),MetricIdParts(Fluff("referrer-"), Host(referrer.getHost())), 1)
-      create(MetricIdParts(Fluff("publishes-paths-"), domainId , Fluff("-"), Host(referrer.getHost())),MetricIdParts(Fluff("path-"), Path(referrer.getPath)), 1)
-    }
+    create(MetricIdParts(Fluff("publishes-uids-"), domainId),MetricIdParts(Fluff("uid-"), viewUid), 1)
+    create(MetricIdParts(Fluff("publishes-hosts-"), viewUid),MetricIdParts(Fluff("referrer-"), Host(referrer.getHost())), 1)
+    create(MetricIdParts(Fluff("publishes-paths-"), viewUid, Fluff("-"), Host(referrer.getHost())),MetricIdParts(Fluff("path-"), Path(referrer.getPath)), 1)
+    create(MetricIdParts(Fluff("publishes-hosts-"), domainId),MetricIdParts(Fluff("referrer-"), Host(referrer.getHost())), 1)
+    create(MetricIdParts(Fluff("publishes-paths-"), domainId , Fluff("-"), Host(referrer.getHost())),MetricIdParts(Fluff("path-"), Path(referrer.getPath)), 1)
   }
 
 

--- a/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/KafkaConsumerCLIBase.scala
+++ b/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/KafkaConsumerCLIBase.scala
@@ -27,7 +27,6 @@ trait KafkaConsumerCLIBase[K,M] extends App {
   //////////////////////////////////////////////////////////////////////////////////////////
   /////// Running the Application
 
-  super.main(args)
   Log.info("Creating Consumer Group")
   val g = consumerGroup()
   Log.info("Completed Creating Consumer Group")

--- a/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/KafkaConsumerCLIBase.scala
+++ b/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/KafkaConsumerCLIBase.scala
@@ -5,14 +5,13 @@ import java.util.Properties
 
 import com.socrata.balboa.metrics.config.Configuration
 import com.socrata.balboa.service.kafka.consumer.KafkaConsumerGroupComponent
-import com.typesafe.scalalogging.slf4j.Logger
 import joptsimple.{OptionParser, OptionSet}
 import kafka.utils.VerifiableProperties
 import org.slf4j.LoggerFactory
 
 /**
- * Base Trait for running a consumer group through a command line application.
- */
+  * Base Trait for running a consumer group through a command line application.
+  */
 trait KafkaConsumerCLIBase[K,M] extends App {
 
   private val Log = LoggerFactory.getLogger(this.getClass)
@@ -28,33 +27,31 @@ trait KafkaConsumerCLIBase[K,M] extends App {
   //////////////////////////////////////////////////////////////////////////////////////////
   /////// Running the Application
 
-  override def main(args: Array[String]): Unit = {
-    super.main(args)
-    Log.info("Creating Consumer Group")
-    val g = consumerGroup()
-    Log.info("Completed Creating Consumer Group")
+  super.main(args)
+  Log.info("Creating Consumer Group")
+  val g = consumerGroup()
+  Log.info("Completed Creating Consumer Group")
 
-    // Add the shutdown hook.
-    Log.info("Adding Shutdown hook")
-    scala.sys.addShutdownHook(try {
-      g.stop()
-    } catch {
-      case e: Exception => Log.warn("Unable to stop consumer group. ", e)
-      case t: Throwable => Log.warn(s"Unknown error while stopping consumer group.", t)
-    })
+  // Add the shutdown hook.
+  Log.info("Adding Shutdown hook")
+  scala.sys.addShutdownHook(try {
+    g.stop()
+  } catch {
+    case e: Exception => Log.warn("Unable to stop consumer group. ", e)
+    case t: Throwable => Log.warn(s"Unknown error while stopping consumer group.", t)
+  })
 
-    Log.info(s"Starting $g...")
-    g.start()
-  }
+  Log.info(s"Starting $g...")
+  g.start()
 
   //////////////////////////////////////////////////////////////////////////////////////////
   /////// Abstract Members
 
   /**
-   * Create a consumer group to Run.
-   *
-   * @return The Consumer Group Component that consumes messages.
-   */
+    * Create a consumer group to Run.
+    *
+    * @return The Consumer Group Component that consumes messages.
+    */
   protected def consumerGroup(): KafkaConsumerGroupComponent[K,M]
 
   //////////////////////////////////////////////////////////////////////////////////////////
@@ -66,19 +63,19 @@ trait KafkaConsumerCLIBase[K,M] extends App {
   lazy val partitions: Int = properties.getInt(TOPIC_PARTITIONS_PROPERTY_KEY)
 
   /**
-   * The properties for this consumer group application.
-   */
+    * The properties for this consumer group application.
+    */
   lazy val properties: VerifiableProperties = new VerifiableProperties(getProperties(args))
 
   /**
-   * Parses command line arguments for properties.
-   * <br>
-   *   Override this method if you introduced a new command line argument and need to validate or extract it.  See
-   *   [[BalboaKafkaConsumerCLI]] as an example.
-   *
-   * @param args Command line arguments
-   * @return Properties for this consumer.
-   */
+    * Parses command line arguments for properties.
+    * <br>
+    *   Override this method if you introduced a new command line argument and need to validate or extract it.  See
+    *   [[BalboaKafkaConsumerCLI]] as an example.
+    *
+    * @param args Command line arguments
+    * @return Properties for this consumer.
+    */
   protected def getProperties(args: Array[String]): Properties = {
     val set: OptionSet = optionParser().parse(args : _*)
     val props = new Properties()
@@ -116,11 +113,11 @@ trait KafkaConsumerCLIBase[K,M] extends App {
   }
 
   /**
-   * Override this method if you want to introduce a new command line argument.  See [[BalboaKafkaConsumerCLI]] as an
-   * example.
-   *
-   * @return The [[OptionParser]] that handles parsing command line input.
-   */
+    * Override this method if you want to introduce a new command line argument.  See [[BalboaKafkaConsumerCLI]] as an
+    * example.
+    *
+    * @return The [[OptionParser]] that handles parsing command line input.
+    */
   protected def optionParser(): OptionParser = {
     val optParser: OptionParser = new OptionParser()
     // Can use a single configuration file for all command line application.
@@ -153,11 +150,11 @@ trait KafkaConsumerCLIBase[K,M] extends App {
   /////// Private Helper methods.
 
   /**
-   * Return the properties created from an existing properties file.
-   *
-   * @param file Configuration file
-   * @return The Properties generated from a file.
-   */
+    * Return the properties created from an existing properties file.
+    *
+    * @param file Configuration file
+    * @return The Properties generated from a file.
+    */
   private def propertiesFromFile(file: File): Properties = file match {
     case _: File if !file.exists() => throw new FileNotFoundException(s"File $file not found")
     case _ =>

--- a/project/BalboaClient.scala
+++ b/project/BalboaClient.scala
@@ -4,7 +4,6 @@ import sbt._
 
 object BalboaClient {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings ++ Seq(
-    crossScalaVersions := Seq("2.8.2", "2.10.4", "2.11.6"),
     libraryDependencies <++= scalaVersion {libraries(_)},
     parallelExecution in Test := false
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -14,7 +14,8 @@ object BuildSettings {
     javaOptions in test += "-Dsocrata.env=test",
     scalacOptions in (Compile, doc) ++= Seq( // Related Issue: http://scala-language.1934581.n4.nabble.com/Scaladoc-2-11-quot-throws-tag-quot-cannot-find-any-member-to-link-td4641850.html
       "-no-link-warnings" // Suppresses problems with Scaladoc @throws links
-    )
+    ),
+    crossScalaVersions := Seq("2.10.6", "2.11.7")
     )
   val projectSettings: Seq[Setting[_]] = buildSettings
 }


### PR DESCRIPTION
* Updated syntax to Scala 2.11 standards
* Update build scripts.