### PR TITLE
Fixed Incorrect Buffer Capacity Def.

### DIFF
--- a/balboa-client-jms/src/main/java/com/blist/metrics/impl/queue/MetricJmsQueueNotSingleton.java
+++ b/balboa-client-jms/src/main/java/com/blist/metrics/impl/queue/MetricJmsQueueNotSingleton.java
@@ -34,7 +34,7 @@ public class MetricJmsQueueNotSingleton extends AbstractJavaMetricQueue {
      * @param connection The Activemq connection.
      * @param queueName The name of the queue to send metrics to.
      * @param bufferCapacity The maximum size of the buffer to maintain.
-     * @throws JMSException When there
+     * @throws JMSException When there is a problem sending to the JMS Server.
      */
     public MetricJmsQueueNotSingleton(Connection connection, String queueName, int bufferCapacity) throws JMSException {
         if (bufferCapacity < 0) {
@@ -50,10 +50,10 @@ public class MetricJmsQueueNotSingleton extends AbstractJavaMetricQueue {
     /**
      * See {@link MetricJmsQueueNotSingleton#MetricJmsQueueNotSingleton(Connection, String, int)}
      *
-     * Uses the default buffer capacity of 1.
+     * Uses the buffer capacity defined by {@link JavaJMSClientConfig#bufferSize()}
      */
     public MetricJmsQueueNotSingleton(Connection connection, String queueName) throws JMSException {
-        this(connection, queueName, 1);
+        this(connection, queueName, JavaJMSClientConfig.bufferSize());
     }
 
     private void flushWriteBuffer() {
@@ -93,7 +93,7 @@ public class MetricJmsQueueNotSingleton extends AbstractJavaMetricQueue {
         // Flush the buffer if it becomes to large.
         // A simpler model given the Java default concurrency model.
         writeBuffer.add(entityId, metrics, timestamp);
-        if (writeBuffer.size() >= JavaJMSClientConfig.bufferSize()) {
+        if (writeBuffer.size() >= this.bufferCapacity) {
             flushWriteBuffer();
         }
     }

--- a/balboa-client/src/main/java/com/blist/metrics/impl/queue/MetricsBuffer.java
+++ b/balboa-client/src/main/java/com/blist/metrics/impl/queue/MetricsBuffer.java
@@ -26,12 +26,12 @@ public class MetricsBuffer {
     private static final Logger log = LoggerFactory.getLogger(MetricsBuffer.class);
 
     /**
-     * This classes is intended to present clients with a simpler interface then exposing the internal buffer
+     * This class is intended to present clients with a simpler interface then exposing the internal buffer
      * directly.  By limiting functionality of the buffer to add and popAll we reduce the chance of unnecessary
      * side effects while allowing us to explore different options for the underlying implementation.
      *
      * TODO: Stronger Unit Tests
-     * TODO: From a functional perspective the internal buffer should probably be a Set.
+     * TODO: From a abstractions perspective the internal buffer should probably be a Set.
      */
 
     /**


### PR DESCRIPTION
* The buffercapacity in MetricJmsQueueNotSingleton was not being
 utilized correctly.  This change fixes that.

NOTE: MetricJmsQueueNotSingleton should be refactored into
MetricJmsQueue.  This changes the interface and I deemed that it should
be released with this patch.