### PR TITLE
Remove the travis-ci build triggers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: scala
-scala:
-  - "2.10.6"
-jdk:
-  - oraclejdk7


### PR DESCRIPTION
Remove the .travis.yml that triggers CI builds in travis. travis-ci is
not our supported mechanism for executing CI builds.