### PR TITLE
Increase ActiveMQ client library logging.

### DIFF
--- a/balboa-agent/src/main/resources/log4j.properties
+++ b/balboa-agent/src/main/resources/log4j.properties
@@ -3,6 +3,17 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] %d{MM-dd-yyyy HH:mm:ss} %c{1.} %M - %m%n
 
+# ActiveMQ does a lot of connection error handling behind the scenes and
+# figuring out what is happening can be obscure. Uncomment this line to bump up
+# the logging from the ActiveMQ client libraries. There is not an overwhelming
+# amount of logs coming out of the library, but it does chat a bit.
+#log4j.logger.org.apache.activemq=DEBUG
+# To specifically target the FailoverTransport logging, which handles
+# connection failovers and retries if you passed a 'failover:' connection
+# string to the ActiveMQConnectionFactory or the ActiveMQConnection, you can
+# uncomment this line:
+log4j.logger.org.apache.activemq.transport.failover=DEBUG
+
 # Example Rolling Log File Appender.
 log4j.appender.rollingFile=org.apache.log4j.RollingFileAppender
 log4j.appender.rollingFile.File=/tmp/agent.log


### PR DESCRIPTION
When there are connection related problems, the ActiveMQ client
libraries handle the connection/reconnection, timeout and failover logic
invisibly. This change adds logging configuration to increase the level
of ActiveMQ logging specifically around connections and failovers. When
experimenting on my local machine, the amount of logging introduced by
this change is something on the order of 1-2 lines every few seconds,
when connection problems are happening.