### PR TITLE
Bump down "Using entity/row key" log message to debug level from info.

### DIFF
--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/Cassandra11QueryImpl.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/Cassandra11QueryImpl.scala
@@ -83,7 +83,7 @@ class Cassandra11QueryImpl(context: AstyanaxContext[Keyspace]) extends Cassandra
 
   def persist(entityId: String, bucket:ju.Date, period: Period, aggregates: sc.Map[String, Metric], absolutes: sc.Map[String, Metric]) {
     val entityKey = Cassandra11Util.createEntityKey(entityId, bucket.getTime)
-    log.info("Using entity/row key " + entityKey + " at period " + period)
+    log.debug("Using entity/row key " + entityKey + " at period " + period)
     fastfail.proceedOrThrow()
 
 


### PR DESCRIPTION
balboa-jms is currently logging ~10 gigs of logs a day, and ~80%
of them are from this one log line, which doesn't seem overly useful
or necessary to log at non-debug levels.