### PR TITLE
Address cross compiling problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ GET /metrics/{entity}/range?
 200: Returns a JSON in the form of:
 
 ```
-
 {
   {metric name 1}: {
     value: {aggregate value for range},
@@ -141,7 +140,7 @@ resolvers := Seq(
 ```
 libraryDependencies ++= Seq(
   ...
-  "com.socrata" % "balboa-client_2.10" % "0.14.0",
+  "com.socrata" %% "balboa-client" % "0.17.6",
   ...
 )
 ```
@@ -217,6 +216,11 @@ INFO - Persisted entity: foo with 1 absolute and 0 aggregated metrics - took 14m
 ## Releases
 
 As of 0.13.0, balboa is versioned with [Semantic Versioning](http://www.semver.org), and uses the [sbt-release](https://github.com/sbt/sbt-release) plugin. To release balboa, run `sbt release` from the project root.
+
+## Development
+
+There is some unique configuration around cross compiling. See comments in the
+build.sbt for more details.
 
 ## License
 Balboa is licensed under the [Apache 2.0](https://github.com/socrata/balboa/blob/master/LICENSE.md) license.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,39 @@
-// TODO Delete... I don't think this is actually be used.
-scalaVersion := "2.10.6"
+//
+// Cross compiling situation
+//
+// As things stand, the balboa-clients need to be cross compiled because they
+// are published as libraries and consumed by both Scala 2.10 and Scala 2.11
+// projects.
+//
+// balboa-http can not be cross compiled because of it's dependency on the
+// socrata-http library. socrata-http is compiled for Scala 2.10 in the version
+// we use, and has a backward incompatible API in the newer versions.
+//
+// Now, odd quirk of sbt, it takes it's crossScalaVersions setting from the
+// project context in which it is invoked, not the project context which is
+// being built. So:
+//
+//     sbt +balboa-client-dispatcher/compile
+//
+// takes the crossScalaVersions value from the balboa project (because it is
+// the root project), not from a setting in balboa-client-dispatcher.
+//
+//     sbt "project balboa-client-dispatcher" "+compile"
+//
+// takes the crossScalaVersions value from the balboa-client-dispatcher
+// project.
+//
+// Because of this sbt oddity, if you are testing cross compiling for any
+// projects, you have to take special action.
+//
+// And because we have a weird shared build script that attempts to accommodate
+// all invocation paths, so needed to remain backwards compatible, the Jenkins
+// build jobs work yet a different way, and are invoked:
+//
+//     sbt "set crossScalaVersion = List("2.10.6", "2.11.7")" "+balboa-client-dispatcher/compile"
+//
 
-crossScalaVersions := Seq("2.10.6", "2.11.7")
+scalaVersion := "2.10.6"
 
 maintainer := "Socrata Mission Control Team, mission-control-l@socrata.com"
 

--- a/project/Balboa.scala
+++ b/project/Balboa.scala
@@ -6,7 +6,6 @@ import sbt._
 
 object Balboa extends Build {
 
-  // WebDav.mkcol := {} Stops this library from trying to publish with WebDav.
   lazy val balboa = Project(
     projectName,
     file("."),

--- a/project/BalboaClient.scala
+++ b/project/BalboaClient.scala
@@ -3,6 +3,8 @@ import sbt.Keys._
 import sbt._
 import scoverage.ScoverageSbtPlugin
 
+// The balboa clients must be cross compiled because there are downstream
+// consumers that use Scala 2.11.
 object BalboaClient {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings ++ Seq(
     libraryDependencies <++= scalaVersion {libraries(_)},

--- a/project/BalboaHttp.scala
+++ b/project/BalboaHttp.scala
@@ -9,6 +9,8 @@ object BalboaHttp {
     ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 0
   )
 
+  // balboa-http can not be cross compiled because of the dependency on
+  // socrata-http.
   def libraries(implicit scalaVersion: String) = Seq(
     junit,
     rojoma_json,


### PR DESCRIPTION
balboa-client-* must be cross compiled for Scala 2.10 and 2.11 because
there are some projects of each version consuming them.

balboa-http can not be cross compiled for Scala 2.11 because the
socrata-http dependency is only in Scala 2.10.

The way our build system works it invokes all sbt tasks from the root
project:

    sbt +balboa-client-dispatcher/compile

When `sbt` is invoked this way, it uses the crossScalaVersions setting
from the root project, not from the project being compiled.

In the end we fixed this by munging the build job on Jenkins to pass an
additional parameter to sbt, thusly:

    sbt 'set crossScalaVersions = List("2.10.6", "2.11.7")' \
        +balboa-client-dispatcher/compile