### PR TITLE
Disable kafka related tests.

### DIFF
--- a/balboa-client-kafka/src/test/scala/com/socrata/balboa/impl/KafkaComponentTests.scala
+++ b/balboa-client-kafka/src/test/scala/com/socrata/balboa/impl/KafkaComponentTests.scala
@@ -33,42 +33,42 @@ with MetricsTestStuff.TestMessages with MetricLoggerToKafka {
   val emergencyQueue = Queue.empty[Message]
   var component: TestComponent = null
 
-  override def setUp(): Unit = {
-    super.setUp()
-    component = new TestComponent() with BalboaKafkaComponent with QueueEmergencyWriter with KafkaProducerInformation {
-      override def brokers: List[AddressAndPort] = AddressAndPort.parse(brokerList)
-      override def file: File = File.createTempFile("emergency", "data")
-      override def topic: String = topic_internal
-    }
-  }
-
-  override def tearDown(): Unit = {
-    emergencyQueue.clear()
-    component.stop()
-    super.tearDown()
-  }
+//  override def setUp(): Unit = {
+//    super.setUp()
+//    component = new TestComponent() with BalboaKafkaComponent with QueueEmergencyWriter with KafkaProducerInformation {
+//      override def brokers: List[AddressAndPort] = AddressAndPort.parse(brokerList)
+//      override def file: File = File.createTempFile("emergency", "data")
+//      override def topic: String = topic_internal
+//    }
+//  }
+//
+//  override def tearDown(): Unit = {
+//    emergencyQueue.clear()
+//    component.stop()
+//    super.tearDown()
+//  }
 
   @Test def testSendAndReceiveOfOneMessage(): Unit = {
-    component.start()
-    component.send(emptyMessage)
-    validateConsumedMessages(emptyMessage)
+//    component.start()
+//    component.send(emptyMessage)
+//    validateConsumedMessages(emptyMessage)
   }
 
-  @Test def testSendAndReceiveOfOneMessageWithoutInitialStart(): Unit = {
-    component.send(emptyMessage)
-    validateConsumedMessages(emptyMessage)
-  }
-
-  @Test def testSendWhenNoServersAreAvailabeWritesToEmergency(): Unit = {
-    servers.foreach(s => {
-      s.shutdown()
-      s.awaitShutdown()
-    })
-    Range(0,3).foreach(_ => component.send(oneElemMessage))
-    assertEquals("When the server is initially down all the messages will be written to the emergence file",
-      3, emergencyQueue.size)
-    assert(emergencyQueue.contains(oneElemMessage))
-  }
+//  @Test def testSendAndReceiveOfOneMessageWithoutInitialStart(): Unit = {
+//    component.send(emptyMessage)
+//    validateConsumedMessages(emptyMessage)
+//  }
+//
+//  @Test def testSendWhenNoServersAreAvailabeWritesToEmergency(): Unit = {
+//    servers.foreach(s => {
+//      s.shutdown()
+//      s.awaitShutdown()
+//    })
+//    Range(0,3).foreach(_ => component.send(oneElemMessage))
+//    assertEquals("When the server is initially down all the messages will be written to the emergence file",
+//      3, emergencyQueue.size)
+//    assert(emergencyQueue.contains(oneElemMessage))
+//  }
 
   def validateConsumedMessages(m: Message*) = {
     val consumedMessages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](m.size,

--- a/balboa-client-kafka/src/test/scala/com/socrata/balboa/impl/MetricLoggerToKafkaTests.scala
+++ b/balboa-client-kafka/src/test/scala/com/socrata/balboa/impl/MetricLoggerToKafkaTests.scala
@@ -36,34 +36,34 @@ class MetricLoggerToKafkaTests extends BalboaMessageClientTestHarness with Metri
 
   var logger: MetricLogger = null
 
-  override def setUp(): Unit = {
-    super.setUp()
-    logger = MetricLogger(brokerList, topic, "file_name_that_does_not_matter")
-  }
-
-  override def tearDown(): Unit = {
-    logger.stop()
-    emergencyQueue.clear()
-    val file = Paths.get("file_name_that_does_not_matter").toFile
-    if (file.exists()) file.delete()
-    super.tearDown()
-  }
+//  override def setUp(): Unit = {
+//    super.setUp()
+//    logger = MetricLogger(brokerList, topic, "file_name_that_does_not_matter")
+//  }
+//
+//  override def tearDown(): Unit = {
+//    logger.stop()
+//    emergencyQueue.clear()
+//    val file = Paths.get("file_name_that_does_not_matter").toFile
+//    if (file.exists()) file.delete()
+//    super.tearDown()
+//  }
 
   @Test def testLoggerSendsMessagesToIdealStateKafka(): Unit = {
-    // TODO For some reason the consumer times out with 60 seconds but not 120.
-    // These test are not deterministic enough.
-    logger.logMetric("mike", "num_penguins", 5, 0L, agg)
-
-    // Flush the buffer to write out all the messages
-    logger.metricDequeuer.actualBuffer.flush()
-    Thread.sleep(2000)
-    val consumedMessages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](1,
-      consumers.head.createMessageStreams[String, Message](Map((topic, 1)), new StringCodec, new BalboaMessageCodec()))
-    // All the outgoing messages should be duplicated by a factor equal to the number of producers
-    assertEquals("Number of total messages sent not equal to the number of total messages received.",
-      1, consumedMessages.size)
-    val m: Message = consumedMessages.unzip._2.head
-    assert(m.getMetrics.containsKey("num_penguins"), "Must contain Penguin sent Metric")
+//    // TODO For some reason the consumer times out with 60 seconds but not 120.
+//    // These test are not deterministic enough.
+//    logger.logMetric("mike", "num_penguins", 5, 0L, agg)
+//
+//    // Flush the buffer to write out all the messages
+//    logger.metricDequeuer.actualBuffer.flush()
+//    Thread.sleep(2000)
+//    val consumedMessages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](1,
+//      consumers.head.createMessageStreams[String, Message](Map((topic, 1)), new StringCodec, new BalboaMessageCodec()))
+//    // All the outgoing messages should be duplicated by a factor equal to the number of producers
+//    assertEquals("Number of total messages sent not equal to the number of total messages received.",
+//      1, consumedMessages.size)
+//    val m: Message = consumedMessages.unzip._2.head
+//    assert(m.getMetrics.containsKey("num_penguins"), "Must contain Penguin sent Metric")
   }
 
   /**
@@ -96,5 +96,3 @@ class MetricLoggerToKafkaTests extends BalboaMessageClientTestHarness with Metri
       lazy val file: File = Files.createTempFile(null, null).toFile
     }
 }
-
-

--- a/balboa-client-kafka/src/test/scala/com/socrata/integration/kafka/util/BalboaClientTestHarnessSpec.scala
+++ b/balboa-client-kafka/src/test/scala/com/socrata/integration/kafka/util/BalboaClientTestHarnessSpec.scala
@@ -17,31 +17,31 @@ class BalboaClientTestHarnessSpec extends StringClientTestHarness {
   override val topic: String = "test_harness_topic"
 
   @Test def testCorrectNumberOfProducers() {
-    assertEquals("Test Harness has incorrect number of producers", producerCount, producers.size)
+//    assertEquals("Test Harness has incorrect number of producers", producerCount, producers.size)
   }
 
-  @Test def testCorrectNumberOfServers() {
-    assertEquals("Test Harness has incorrect number of servers", serverCount, servers.size)
-  }
-
-  @Test def testCorrectNumberOfConsumers() {
-    assertEquals("Test Harness has incorrect number of consumer", consumerCount, consumers.size)
-    assertEquals("There should be only one consumer group", 1, consumerMap.keys.size)
-    assertEquals("There should be only one consumer for that specific consumer group", 1, consumerMap(0).size)
-  }
-
-  /**
-   * Simple test to show that we can consume messages.
-   */
-  @Test def testMessageEndToEndness(): Unit = {
-    val m = "Hello Balboa Client Test Harness parameterized World!"
-    producers(0).send(m)
-
-    // Example of how to consume messages and test we actually received them.
-    val messages: List[(String,String)] = BalboaClientTestUtils.getKeysAndMessages[String,String](1,
-      consumers(0).createMessageStreams[String, String](
-      Map((topic, 1)), new StringCodec, new StringCodec))
-    assert(messages.unzip._2.contains(m))
-  }
+//  @Test def testCorrectNumberOfServers() {
+//    assertEquals("Test Harness has incorrect number of servers", serverCount, servers.size)
+//  }
+//
+//  @Test def testCorrectNumberOfConsumers() {
+//    assertEquals("Test Harness has incorrect number of consumer", consumerCount, consumers.size)
+//    assertEquals("There should be only one consumer group", 1, consumerMap.keys.size)
+//    assertEquals("There should be only one consumer for that specific consumer group", 1, consumerMap(0).size)
+//  }
+//
+//  /**
+//   * Simple test to show that we can consume messages.
+//   */
+//  @Test def testMessageEndToEndness(): Unit = {
+//    val m = "Hello Balboa Client Test Harness parameterized World!"
+//    producers(0).send(m)
+//
+//    // Example of how to consume messages and test we actually received them.
+//    val messages: List[(String,String)] = BalboaClientTestUtils.getKeysAndMessages[String,String](1,
+//      consumers(0).createMessageStreams[String, String](
+//      Map((topic, 1)), new StringCodec, new StringCodec))
+//    assert(messages.unzip._2.contains(m))
+//  }
 
 }

--- a/balboa-client-kafka/src/test/scala/com/socrata/metrics/producer/BalboaKafkaProducerScenario1Tests.scala
+++ b/balboa-client-kafka/src/test/scala/com/socrata/metrics/producer/BalboaKafkaProducerScenario1Tests.scala
@@ -30,64 +30,64 @@ with MetricsTestStuff.TestMessages {
   override val topic: String = "balboa_kafka_producer_topic"
 
   @Test def testSendingSingleMessageIsEventuallyConsumed(): Unit = {
-    producers(0).send(oneElemMessage)
-
-    val messages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](1,
-      consumers(0).createMessageStreams[String, Message](
-        Map((topic, 1)), new StringCodec, new BalboaMessageCodec()))
-    assertEquals("Must have one element", 1, messages.size)
-    assert(messages.unzip._2.contains(oneElemMessage))
+//    producers(0).send(oneElemMessage)
+//
+//    val messages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](1,
+//      consumers(0).createMessageStreams[String, Message](
+//        Map((topic, 1)), new StringCodec, new BalboaMessageCodec()))
+//    assertEquals("Must have one element", 1, messages.size)
+//    assert(messages.unzip._2.contains(oneElemMessage))
   }
 
-  /**
-   * The current specification defines that mutliple producers that happen to send the same message will result in the
-   * duplication for a specific consumer group.
-   */
-  @Test def testMultipleProducersSendTheSameMessageGetsDuplicates() =
-    downServerTestHelper(servers.slice(0,0), producers.slice(0,2), oneElemMessage)
-
-  @Test def testDownServerAndSendMessage() =
-    downServerTestHelper(servers.slice(0, 1), producers.slice(0,1), oneElemMessage, oneElemMessage, manyElemMessage)
-
-  @Test def testTwoDownServerAndSendMessage() =
-    downServerTestHelper(servers.slice(0, 2), producers.slice(0,1), oneElemMessage)
-
-  // TODO: Hmm this should fail. Replication factor 3 with 3 out of 4 servers down.????
-  @Test def testThreeDownServerAndSendMessage(): Unit =
-    downServerTestHelper(servers.slice(0, 3), producers.slice(0,1), oneElemMessage)
-
-  @Test def testFailedToSendMessageWithAllServerDown(): Unit = {
-    // Sending a message should fail because all the servers are down.
-    intercept[FailedToSendMessageException](downServerTestHelper(servers.slice(0,4), producers.slice(0,1), manyElemMessage))
-  }
-
-  def downServerTestHelper(downServers: Seq[KafkaServer],
-                           producers: Seq[GenericKafkaProducer[String,Message,StringCodec,BalboaMessageCodec]],
-                           inputMessages: Message*) = {
-    downServers.foreach(s => {
-      s.shutdown()
-      s.awaitShutdown()
-    })
-
-    producers.foreach(p => {
-      inputMessages.foreach(message => p.send(message))
-    })
-
-    consumerMap.foreach(x => {
-      val expectedSize = inputMessages.size * producers.size
-      // Little complex looking but this is just using the single consumer in each group to create a stream of messages
-      // and then pulls the 2 messages from the stream to verify and store in "messages"
-      val consumedMessages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](expectedSize,
-        x._2(0).createMessageStreams[String, Message](Map((topic, 1)), new StringCodec, new BalboaMessageCodec()))
-
-      // All the outgoing messages should be duplicated by a factor equal to the number of producers
-      assertEquals("Number of total messages sent not equal to the number of total messages received.",
-        expectedSize, consumedMessages.size)
-
-      // Each outgoing message must be contained in the eventually consumed message.
-      assert(inputMessages.forall(inMessage => {consumedMessages.unzip._2.contains(inMessage)}),
-        "All the input messages should be contained in the output.")
-    })
-  }
+//  /**
+//   * The current specification defines that mutliple producers that happen to send the same message will result in the
+//   * duplication for a specific consumer group.
+//   */
+//  @Test def testMultipleProducersSendTheSameMessageGetsDuplicates() =
+//    downServerTestHelper(servers.slice(0,0), producers.slice(0,2), oneElemMessage)
+//
+//  @Test def testDownServerAndSendMessage() =
+//    downServerTestHelper(servers.slice(0, 1), producers.slice(0,1), oneElemMessage, oneElemMessage, manyElemMessage)
+//
+//  @Test def testTwoDownServerAndSendMessage() =
+//    downServerTestHelper(servers.slice(0, 2), producers.slice(0,1), oneElemMessage)
+//
+//  // TODO: Hmm this should fail. Replication factor 3 with 3 out of 4 servers down.????
+//  @Test def testThreeDownServerAndSendMessage(): Unit =
+//    downServerTestHelper(servers.slice(0, 3), producers.slice(0,1), oneElemMessage)
+//
+//  @Test def testFailedToSendMessageWithAllServerDown(): Unit = {
+//    // Sending a message should fail because all the servers are down.
+//    intercept[FailedToSendMessageException](downServerTestHelper(servers.slice(0,4), producers.slice(0,1), manyElemMessage))
+//  }
+//
+//  def downServerTestHelper(downServers: Seq[KafkaServer],
+//                           producers: Seq[GenericKafkaProducer[String,Message,StringCodec,BalboaMessageCodec]],
+//                           inputMessages: Message*) = {
+//    downServers.foreach(s => {
+//      s.shutdown()
+//      s.awaitShutdown()
+//    })
+//
+//    producers.foreach(p => {
+//      inputMessages.foreach(message => p.send(message))
+//    })
+//
+//    consumerMap.foreach(x => {
+//      val expectedSize = inputMessages.size * producers.size
+//      // Little complex looking but this is just using the single consumer in each group to create a stream of messages
+//      // and then pulls the 2 messages from the stream to verify and store in "messages"
+//      val consumedMessages: List[(String,Message)] = BalboaClientTestUtils.getKeysAndMessages[String,Message](expectedSize,
+//        x._2(0).createMessageStreams[String, Message](Map((topic, 1)), new StringCodec, new BalboaMessageCodec()))
+//
+//      // All the outgoing messages should be duplicated by a factor equal to the number of producers
+//      assertEquals("Number of total messages sent not equal to the number of total messages received.",
+//        expectedSize, consumedMessages.size)
+//
+//      // Each outgoing message must be contained in the eventually consumed message.
+//      assert(inputMessages.forall(inMessage => {consumedMessages.unzip._2.contains(inMessage)}),
+//        "All the input messages should be contained in the output.")
+//    })
+//  }
   
 }

--- a/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/BalboaConsumerGroupIntegrationTest.scala
+++ b/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/BalboaConsumerGroupIntegrationTest.scala
@@ -1,16 +1,9 @@
 package com.socrata.balboa.service.kafka.consumer
 
-import java.util.concurrent.Future
 import com.socrata.balboa.util.MetricsTestStuff
 import MetricsTestStuff.TestMessages
 import com.socrata.balboa.metrics.Message
 import com.socrata.balboa.service.kafka.test.util.StagingAndRCServiceTestHarness
-import com.socrata.balboa.util.MetricsTestStuff
-import kafka.consumer.{ConsumerConfig, ConsumerTimeoutException}
-import kafka.utils.TestUtils
-import org.junit.Assert._
-import org.junit.Test
-
 
 /**
  * Test for [[BalboaConsumerGroup]].
@@ -23,60 +16,60 @@ class BalboaConsumerGroupIntegrationTest extends StagingAndRCServiceTestHarness 
 
   override val CONSUMER_TIMEOUT_MS = 1000
 
-  override def tearDown(): Unit = {
-    consumerGroup1.stop()
-    dataStore.metricMap.clear()
-    super.tearDown()
-  }
-
-  override def setUp(): Unit = {
-    super.setUp()
-    consumerGroup1 = genConsumerGroup(new ConsumerConfig(
-      TestUtils.createConsumerProperties(zkConnect, "group_1", "consumer_1")) {
-      // NOTE: Important in testing environments we need consumers to terminate when there "appears" to be no more messages.
-      // For some reason we have to over the time out
-      override val consumerTimeoutMs = CONSUMER_TIMEOUT_MS
-    })
-    assertEquals("Consumer Group size is not equivalent to the number of partitions", numPartitions, consumerGroup1.consumers.size)
-  }
+//  override def tearDown(): Unit = {
+//    consumerGroup1.stop()
+//    dataStore.metricMap.clear()
+//    super.tearDown()
+//  }
+//
+//  override def setUp(): Unit = {
+//    super.setUp()
+//    consumerGroup1 = genConsumerGroup(new ConsumerConfig(
+//      TestUtils.createConsumerProperties(zkConnect, "group_1", "consumer_1")) {
+//      // NOTE: Important in testing environments we need consumers to terminate when there "appears" to be no more messages.
+//      // For some reason we have to over the time out
+//      override val consumerTimeoutMs = CONSUMER_TIMEOUT_MS
+//    })
+//    assertEquals("Consumer Group size is not equivalent to the number of partitions", numPartitions, consumerGroup1.consumers.size)
+//  }
 
   /**
    * When there are no messages sent then all the consumers should timeout.
    */
-  @Test def testConsumerReceivesNothingIfNoMessagesAreSentAndFailsNormally(): Unit = {
-    testMessages(Seq.empty)
+  def testConsumerReceivesNothingIfNoMessagesAreSentAndFailsNormally(): Unit = {
+//    testMessages(Seq.empty)
   }
 
-  /**
-   * Make sure one message makes it end to end from [[com.socrata.metrics.producer.GenericKafkaProducer]] to
-   * [[BalboaConsumerGroup]]
-   */
-  @Test def testConsumerReceivesOneSentMessage() {
-    testMessages(Seq(oneElemMessage))
-  }
-
-  /**
-   * Make sure multiple messages make end to end and maintain the correct state.
-   */
-  @Test def testManyMessages(): Unit = {
-    // TODO Identify the number of messages that best resembles the actual number the traffic through real environments.
-    testMessages(Range(0, 10000).map(i => MetricsTestStuff.message(s"entity_$i",
-      MetricsTestStuff.metrics((s"metric_$i", MetricsTestStuff.metric(i))), i)))
-  }
-
-  private def testMessages(messages: Seq[Message]): Unit = {
-    messages.foreach(m => producers(0).send(m))
-    val futures: List[Future[_]] = consumerGroup1.start()
-    futures.foreach(f => f.get() match {
-      case Some(cte: ConsumerTimeoutException) => // Success
-      case Some(e: Exception) => fail("Caught unexpected exception", e)
-      case None => fail(s"Expection expected but not caught")
-    })
-    val expectedSize = messages.size
-    assertEquals(expectedSize, dataStore.metricMap.size())
-    assertTrue(s"All $expectedSize metrics entries were not found in $dataStore",
-      messages.forall(m => dataStore.metricMap.containsKey(m.getEntityId)
-        && dataStore.metricMap.get(m.getEntityId).equals(m.getMetrics)))
-  }
+//  /**
+//   * Make sure one message makes it end to end from [[com.socrata.metrics.producer.GenericKafkaProducer]] to
+//   * [[BalboaConsumerGroup]]
+//   */
+//  def testConsumerReceivesOneSentMessage() {
+//    testMessages(Seq(oneElemMessage))
+//  }
+//
+//  /**
+//   * Make sure multiple messages make end to end and maintain the correct state.
+//   */
+//  def testManyMessages(): Unit = {
+//    // TODO Identify the number of messages that best resembles the actual number the traffic through real environments.
+//    testMessages(Range(0, 10000).map(i => MetricsTestStuff.message(s"entity_$i",
+//      MetricsTestStuff.metrics((s"metric_$i", MetricsTestStuff.metric(i))), i)))
+//  }
+//
+//  private def testMessages(messages: Seq[Message]): Unit = {
+//    messages.foreach(m => producers(0).send(m))
+//    val futures: List[Future[_]] = consumerGroup1.start()
+//    futures.foreach(f => f.get() match {
+//      case Some(cte: ConsumerTimeoutException) => // Success
+//      case Some(e: Exception) => fail("Caught unexpected exception", e)
+//      case None => fail(s"Expection expected but not caught")
+//    })
+//    val expectedSize = messages.size
+//    assertEquals(expectedSize, dataStore.metricMap.size())
+//    assertTrue(s"All $expectedSize metrics entries were not found in $dataStore",
+//      messages.forall(m => dataStore.metricMap.containsKey(m.getEntityId)
+//        && dataStore.metricMap.get(m.getEntityId).equals(m.getMetrics)))
+//  }
 
 }

--- a/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/BalboaConsumerTests.scala
+++ b/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/BalboaConsumerTests.scala
@@ -52,43 +52,43 @@ class BalboaConsumerSpec extends WordSpec with BeforeAndAfterEach {
 
   override protected def afterEach(): Unit = BalboaFastFailCheck.getInstance().markSuccess()
 
-  "A Balboa Consumer Component" should {
-
-    "persist 1 entry to the data store" in new TestBalboaKafkaConsumerSetup {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
-      val json: JsonMessage = ConsumerTestUtil.testJSONMetric("test_metric", 1)
-      val mm = ConsumerTestUtil.message(null, json, stringCodec, messageCodec)
-      Mockito.when(mIterator.next()).thenReturn(mm)
-      balboaConsumer.start()
-      Mockito.verify(mDS).persist(json.getEntityId, json.getTimestamp, json.getMetrics)
-    }
-
-    "persist multiple entries to the data store" in new TestBalboaKafkaConsumerSetup {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, true, true, true, true, false)
-      var jsons: List[JsonMessage] = List[JsonMessage]()
-      var mms = List[MessageAndMetadata[String, Message]]()
-      for (i <- 1 to 5) {
-        val json = ConsumerTestUtil.testJSONMetric(s"test_metric_$i", i)
-        jsons = jsons :+ json
-        mms = mms :+ ConsumerTestUtil.message(null, json, stringCodec, messageCodec)
-      }
-
-      Mockito.when(mIterator.next()).thenReturn(mms(0), mms(1), mms(2), mms(3), mms(4))
-      balboaConsumer.start()
-      jsons.foreach(j => Mockito.verify(mDS).persist(j.getEntityId, j.getTimestamp, j.getMetrics))
-    }
-
-    // TODO This test is temprarily not working.  Its a mock object thing.
-    // Currently the test in Persistent Consumer Spec test failing to persist.
-//    "handle temporarily down datastore" in new TestBalboaConsumer {
+//  "A Balboa Consumer Component" should {
+//
+//    "persist 1 entry to the data store" in new TestBalboaKafkaConsumerSetup {
 //      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
 //      val json: JsonMessage = ConsumerTestUtil.testJSONMetric("test_metric", 1)
-//      val mm = ConsumerTestUtil.message(json)
+//      val mm = ConsumerTestUtil.message(null, json, stringCodec, messageCodec)
 //      Mockito.when(mIterator.next()).thenReturn(mm)
-//      Mockito.when(mDS.persist(json.getEntityId, json.getTimestamp, json.getMetrics)).thenThrow(classOf[IOException])
-//        .thenReturn(())
-//      balboaConsumer.run()
+//      balboaConsumer.start()
 //      Mockito.verify(mDS).persist(json.getEntityId, json.getTimestamp, json.getMetrics)
 //    }
-  }
+//
+//    "persist multiple entries to the data store" in new TestBalboaKafkaConsumerSetup {
+//      Mockito.when(mIterator.hasNext()).thenReturn(true, true, true, true, true, false)
+//      var jsons: List[JsonMessage] = List[JsonMessage]()
+//      var mms = List[MessageAndMetadata[String, Message]]()
+//      for (i <- 1 to 5) {
+//        val json = ConsumerTestUtil.testJSONMetric(s"test_metric_$i", i)
+//        jsons = jsons :+ json
+//        mms = mms :+ ConsumerTestUtil.message(null, json, stringCodec, messageCodec)
+//      }
+//
+//      Mockito.when(mIterator.next()).thenReturn(mms(0), mms(1), mms(2), mms(3), mms(4))
+//      balboaConsumer.start()
+//      jsons.foreach(j => Mockito.verify(mDS).persist(j.getEntityId, j.getTimestamp, j.getMetrics))
+//    }
+//
+//    // TODO This test is temprarily not working.  Its a mock object thing.
+//    // Currently the test in Persistent Consumer Spec test failing to persist.
+////    "handle temporarily down datastore" in new TestBalboaConsumer {
+////      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
+////      val json: JsonMessage = ConsumerTestUtil.testJSONMetric("test_metric", 1)
+////      val mm = ConsumerTestUtil.message(json)
+////      Mockito.when(mIterator.next()).thenReturn(mm)
+////      Mockito.when(mDS.persist(json.getEntityId, json.getTimestamp, json.getMetrics)).thenThrow(classOf[IOException])
+////        .thenReturn(())
+////      balboaConsumer.run()
+////      Mockito.verify(mDS).persist(json.getEntityId, json.getTimestamp, json.getMetrics)
+////    }
+//  }
 }

--- a/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/KafkaConsumerComponentTests.scala
+++ b/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/KafkaConsumerComponentTests.scala
@@ -74,67 +74,67 @@ class KafkaConsumerComponentSpec extends WordSpec with TestKafkaConsumerComponen
 
   override protected def beforeEach(): Unit = super.beforeEach()
 
-  "A Kafka Consumer Component" should {
-
-    "not consume messages when the stream is empty" in new TestKafkaConsumerSetup {
-      Mockito.when(mIterator.hasNext()).thenReturn(false)
-      kafkaConsumer.start()
-      assert(kafkaConsumer.queue.isEmpty, "No messages should have been added with a null")
-    }
-
-    "consume a single message exactly one is available" in new TestKafkaConsumerSetup {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
-      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("key", "message", scodec, scodec))
-      kafkaConsumer.start()
-      assert(kafkaConsumer.queue.size == 1, "No messages should have been added with a null")
-      assert(kafkaConsumer.queue.exists(km => km._1.equals("key")  && km._2.equals("message")))
-    }
-
-    "consume multiple messages" in new TestKafkaConsumerSetup {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, true, true, true, true, false)
-      Mockito.when(mIterator.next()).thenReturn(
-        ConsumerTestUtil.message(null, "test_message1", scodec, scodec),
-        ConsumerTestUtil.message(null, "test_message2", scodec, scodec),
-        ConsumerTestUtil.message(null, "test_message3", scodec, scodec),
-        ConsumerTestUtil.message(null, "test_message4", scodec, scodec),
-        ConsumerTestUtil.message(null, "test_message5", scodec, scodec))
-
-      kafkaConsumer.start()
-
-      assert(kafkaConsumer.queue.size == 5, "Should have 5 elements")
-      for (i <- 1 to 5) {
-        assert(kafkaConsumer.queue.exists(km => km._1 == null && km._2 == s"test_message$i"),
-          "The ingested message is not the same as the one " +
-            "produced by the iterator")
-      }
-    }
-
-    "wait until consumer is ready before continuing." in new TestKafkaConsumerSetup {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
-      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("test_key", "test_message", scodec, scodec))
-      isReady.set(false)
-
-      // Run the consumer and have it block until it is ready
-      val s1: ExecutorService = Executors.newFixedThreadPool(1)
-      s1.submit(kafkaConsumer)
-
-      val service: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
-      service.schedule(new Runnable {
-        override def run(): Unit = {
-          assert(kafkaConsumer.queue.isEmpty, "No messages should have been added ")
-          isReady.set(true)
-        }
-      }, wt * 2, TimeUnit.MILLISECONDS)
-
-      service.awaitTermination(wt * 3, TimeUnit.MILLISECONDS)
-      s1.awaitTermination(wt, TimeUnit.MILLISECONDS)
-      // isReady should be set to true by now.
-
-      assert(kafkaConsumer.queue.size == 1, "Should have exactly one element")
-      assert(kafkaConsumer.queue.exists(km => km._1 == "test_key" && km._2 == "test_message"), "The ingested message is not " +
-        "the same as the one produced by the iterator")
-    }
-  }
+//  "A Kafka Consumer Component" should {
+//
+//    "not consume messages when the stream is empty" in new TestKafkaConsumerSetup {
+//      Mockito.when(mIterator.hasNext()).thenReturn(false)
+//      kafkaConsumer.start()
+//      assert(kafkaConsumer.queue.isEmpty, "No messages should have been added with a null")
+//    }
+//
+//    "consume a single message exactly one is available" in new TestKafkaConsumerSetup {
+//      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
+//      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("key", "message", scodec, scodec))
+//      kafkaConsumer.start()
+//      assert(kafkaConsumer.queue.size == 1, "No messages should have been added with a null")
+//      assert(kafkaConsumer.queue.exists(km => km._1.equals("key")  && km._2.equals("message")))
+//    }
+//
+//    "consume multiple messages" in new TestKafkaConsumerSetup {
+//      Mockito.when(mIterator.hasNext()).thenReturn(true, true, true, true, true, false)
+//      Mockito.when(mIterator.next()).thenReturn(
+//        ConsumerTestUtil.message(null, "test_message1", scodec, scodec),
+//        ConsumerTestUtil.message(null, "test_message2", scodec, scodec),
+//        ConsumerTestUtil.message(null, "test_message3", scodec, scodec),
+//        ConsumerTestUtil.message(null, "test_message4", scodec, scodec),
+//        ConsumerTestUtil.message(null, "test_message5", scodec, scodec))
+//
+//      kafkaConsumer.start()
+//
+//      assert(kafkaConsumer.queue.size == 5, "Should have 5 elements")
+//      for (i <- 1 to 5) {
+//        assert(kafkaConsumer.queue.exists(km => km._1 == null && km._2 == s"test_message$i"),
+//          "The ingested message is not the same as the one " +
+//            "produced by the iterator")
+//      }
+//    }
+//
+//    "wait until consumer is ready before continuing." in new TestKafkaConsumerSetup {
+//      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
+//      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("test_key", "test_message", scodec, scodec))
+//      isReady.set(false)
+//
+//      // Run the consumer and have it block until it is ready
+//      val s1: ExecutorService = Executors.newFixedThreadPool(1)
+//      s1.submit(kafkaConsumer)
+//
+//      val service: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
+//      service.schedule(new Runnable {
+//        override def run(): Unit = {
+//          assert(kafkaConsumer.queue.isEmpty, "No messages should have been added ")
+//          isReady.set(true)
+//        }
+//      }, wt * 2, TimeUnit.MILLISECONDS)
+//
+//      service.awaitTermination(wt * 3, TimeUnit.MILLISECONDS)
+//      s1.awaitTermination(wt, TimeUnit.MILLISECONDS)
+//      // isReady should be set to true by now.
+//
+//      assert(kafkaConsumer.queue.size == 1, "Should have exactly one element")
+//      assert(kafkaConsumer.queue.exists(km => km._1 == "test_key" && km._2 == "test_message"), "The ingested message is not " +
+//        "the same as the one produced by the iterator")
+//    }
+//  }
 }
 
 

--- a/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/PersistentConsumerComponentTests.scala
+++ b/balboa-service-kafka/src/test/scala/com/socrata/balboa/service/kafka/consumer/PersistentConsumerComponentTests.scala
@@ -74,28 +74,28 @@ class PersistentConsumerComponentSpec extends WordSpec with BeforeAndAfterEach {
 
   private val scodec = new StringCodec()
 
-  "A Persistent Consumer Component" should {
-
-    "retry when initial persist fails" taggedAs SlowTest in new ConfigurableTestPersistentKafkaConsumerSetup(1,2) {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
-      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("test_key", "test_message", scodec, scodec))
-
-
-      kafkaConsumer.start()
-      assert(kafkaConsumer.queue.size == 1, "Should have exactly one element")
-      assert(kafkaConsumer.queue.exists(km => km._1 == "test_key" && km._2 == "test_message"),
-        "Message does not eventually become consumed.")
-    }
-
-    "throws exception when it retries more than 2 times" taggedAs SlowTest in new ConfigurableTestPersistentKafkaConsumerSetup(2,2) {
-      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
-      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("test_key", "test_message", scodec, scodec))
-
-      intercept[IOException] {
-        kafkaConsumer.start()
-        assert(kafkaConsumer.queue.size == 0, "Should have no one elements")
-      }
-    }
-
-  }
+//  "A Persistent Consumer Component" should {
+//
+//    "retry when initial persist fails" taggedAs SlowTest in new ConfigurableTestPersistentKafkaConsumerSetup(1,2) {
+//      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
+//      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("test_key", "test_message", scodec, scodec))
+//
+//
+//      kafkaConsumer.start()
+//      assert(kafkaConsumer.queue.size == 1, "Should have exactly one element")
+//      assert(kafkaConsumer.queue.exists(km => km._1 == "test_key" && km._2 == "test_message"),
+//        "Message does not eventually become consumed.")
+//    }
+//
+//    "throws exception when it retries more than 2 times" taggedAs SlowTest in new ConfigurableTestPersistentKafkaConsumerSetup(2,2) {
+//      Mockito.when(mIterator.hasNext()).thenReturn(true, false)
+//      Mockito.when(mIterator.next()).thenReturn(ConsumerTestUtil.message("test_key", "test_message", scodec, scodec))
+//
+//      intercept[IOException] {
+//        kafkaConsumer.start()
+//        assert(kafkaConsumer.queue.size == 0, "Should have no one elements")
+//      }
+//    }
+//
+//  }
 }

--- a/project/BalboaClient.scala
+++ b/project/BalboaClient.scala
@@ -35,7 +35,7 @@ object BalboaClientKafka {
     libraryDependencies <++= scalaVersion {libraries(_)},
     parallelExecution in Test := false,
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
-    ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 74
+    ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 0
   )
 
   def libraries(implicit scalaVersion: String) = BalboaClient.libraries ++ BalboaKafkaCommon.libraries

--- a/project/BalboaService.scala
+++ b/project/BalboaService.scala
@@ -53,7 +53,7 @@ object BalboaKafka {
     mainClass in assembly := Some("com.socrata.balboa.service.kafka.BalboaKafkaConsumerCLI"),
     libraryDependencies <++= scalaVersion {libraries(_)},
     parallelExecution in Test := false,
-    ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 42
+    ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 0
   )
 
   def libraries(implicit scalaVersion: String) = BalboaService.libraries ++ BalboaKafkaCommon.libraries


### PR DESCRIPTION
These tests are unstable and inconsistent on Jenkins, which is a real
barrier to pull requests. More to the point, we no longer support Kafka.
There is future work to delete this code:

    https://socrata.atlassian.net/browse/EN-6069

For the moment, just disabling it.