### PR TITLE
EN-7053 - Add support for DC in C* configuration

### DIFF
--- a/balboa-http/docker/balboa.properties.j2
+++ b/balboa-http/docker/balboa.properties.j2
@@ -2,4 +2,7 @@ cassandra.servers = {{ CASSANDRAS }}
 cassandra.keyspace = {{ CASSANDRA_KEYSPACE }}
 cassandra.maxpoolsize = {{ CASSANDRA_MAXPOOLSIZE }}
 cassandra.sotimeout = {{ CASSANDRA_SOTIMEOUT }}
+{% if CASSANDRA_DATACENTER is defined -%}
+cassandra.datacenter = {{ CASSANDRA_DATACENTER }}
+{%- endif %}
 balboa.datastore = cassandra

--- a/balboa-service-jms/docker/balboa.properties.j2
+++ b/balboa-service-jms/docker/balboa.properties.j2
@@ -1,3 +1,6 @@
 cassandra.servers = {{ CASSANDRAS }}
 cassandra.keyspace = {{ CASSANDRA_KEYSPACE }}
+{% if CASSANDRA_DATACENTER is defined -%}
+cassandra.datacenter = {{ CASSANDRA_DATACENTER }}
+{%- endif %}
 balboa.datastore = cassandra

--- a/balboa-service-kafka/docker/balboa-kafka.properties.j2
+++ b/balboa-service-kafka/docker/balboa-kafka.properties.j2
@@ -4,6 +4,9 @@
 cassandra.servers = {{ CASSANDRAS }}
 cassandra.keyspace = Metrics2012
 cassandra.retries = {{ CASSANDRA_RETRIES }}
+{% if CASSANDRA_DATACENTER is defined -%}
+cassandra.datacenter = {{ CASSANDRA_DATACENTER }}
+{%- endif %}
 balboa.datastore = buffered-cassandra
 
 # Kafka Properties


### PR DESCRIPTION
If Cassandra datacenter is specified in configuration properties, apply
it as a DC local configuration.  Otherwise, behave as it has previously.