### PR TITLE
Add badcall integration tests and protobuf response code tests to balboa-http

### DIFF
--- a/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
+++ b/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
@@ -36,8 +36,8 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   }
   implicit def convertJSONAssertion(j: => String): AssertionJSON = new AssertionJSON(j)
 
-  def getHttpResponse(url: URL): HttpResponse = {
-    Await.result(GET(url).apply, Config.RequestTimeout)
+  def getHttpResponse(url: String): HttpResponse = {
+    Await.result(GET(new URL(Config.Server, url)).apply, Config.RequestTimeout)
   }
 
   // Ensures each test interacts with a unique entity
@@ -46,20 +46,17 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   }
 
   "Retrieve /metrics range with no range" should "be fail" in {
-    val url = new URL(Config.Server, "/metrics/fake.name/range")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse("/metrics/fake.name/range")
     response.code.code should be (BadRequest.code)
   }
 
   "Retrieve /metrics without specifying" should "be not found" in {
-    val url = new URL(Config.Server, "/metrics")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse("/metrics")
     response.code.code should be (NotFound.code)
   }
 
   "Retrieve /metrics range with a range" should "succeed" in {
-    val url = new URL(Config.Server, "/metrics/fake.name/range?start=2010-01-01+00%3A00%3A00%3A000&end=2017-01-01+00%3A00%3A00%3A000")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse("/metrics/fake.name/range?start=2010-01-01+00%3A00%3A00%3A000&end=2017-01-01+00%3A00%3A00%3A000")
     response.code.code should be (Ok.code)
     response.bodyString shouldBeJSON """{}"""
   }
@@ -92,8 +89,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
 
   "Retrieve /metrics range after persisting" should "show persisted metrics" in {
     val expected = persistSingleMetric()
-    val url = new URL(Config.Server, s"metrics/$testEntityName/range?start=1969-01-01&end=1970-02-02")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse("metrics/" + testEntityName + "/range?start=1969-01-01&end=1970-02-02")
     response.code.code should be (Ok.code)
     response.bodyString shouldBeJSON expected
   }
@@ -101,8 +97,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   "Retrieve /metrics range after persisting multiple metrics" should "show multiple persisted metrics" in {
     val metRange = 1 to 10
     val expected = persistManyMetrics(metRange)
-    val url = new URL(Config.Server, s"metrics/$testEntityName/range?start=1969-01-01&end=1970-02-02")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse(s"metrics/$testEntityName/range?start=1969-01-01&end=1970-02-02")
     response.code.code should be (Ok.code)
 
 
@@ -112,8 +107,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   "Retrieve /metrics series after persisting" should "show persisted metrics" in {
     val expectedMetric = persistSingleMetric()
 
-    val url = new URL(Config.Server, s"metrics/$testEntityName/series?period=MONTHLY&start=1969-12-01&end=1970-02-02")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse(s"metrics/$testEntityName/series?period=MONTHLY&start=1969-12-01&end=1970-02-02")
     response.code.code should be (Ok.code)
 
     val expectSeries1 = """ { "start" : -2678400000, "end" : -1, "metrics" : { } } """
@@ -127,8 +121,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
     val metRange = 1 to 10
     val expectedMetrics = persistManyMetrics(metRange)
 
-    val url = new URL(Config.Server, s"metrics/$testEntityName/series?period=MONTHLY&start=1969-12-01&end=1970-02-02")
-    val response = getHttpResponse(url)
+    val response = getHttpResponse(s"metrics/$testEntityName/series?period=MONTHLY&start=1969-12-01&end=1970-02-02")
     response.code.code should be (Ok.code)
 
     val expectSeries1 = """ { "start" : -2678400000, "end" : -1, "metrics" : { } } """

--- a/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
+++ b/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
@@ -114,6 +114,23 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
     response.code.code should be (Ok.code)
   }
 
+  "Retrieve /metrics/*/range with no start" should "fail with error msg" in {
+    val response = awaitResponse(s"/metrics/$testEntName/range")
+    response.code.code should be (BadRequest.code)
+    response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter start required." } """
+  }
+
+  "Retrieve /metrics/*/range with no end" should "fail with error msg" in {
+    val response = awaitResponse(s"/metrics/$testEntName/range?start=1969-01-01")
+    response.code.code should be (BadRequest.code)
+    response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter end required." } """
+  }
+
+  "Retrieve /metrics/*/range with start and end" should "succeed" in {
+    val response = awaitResponse(s"/metrics/$testEntName/range?start=1969-01-01&end=1970-02-02")
+    response.code.code should be (Ok.code)
+  }
+
   // Returns the JSON string representation of the metric added
   def persistSingleMetric(): String = {
     val metrics = new Metrics()

--- a/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
+++ b/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
@@ -22,6 +22,8 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   val testMetricName = "testMetricsPersisted"
   val testEntityPrefix = "testMetricsEntity"
   var testEntityName = ""
+  val testStart = "1969-12-01"
+  val testEnd = "1970-02-02"
 
   class AssertionJSON(j: => String) {
     def shouldBeJSON(expected: String) = {
@@ -56,7 +58,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   }
 
   "Retrieve /metrics range with a range" should "succeed" in {
-    val response = getHttpResponse(s"/metrics/$testEntityName/range?start=2010-01-01+00%3A00%3A00%3A000&end=2017-01-01+00%3A00%3A00%3A000")
+    val response = getHttpResponse(s"/metrics/$testEntityName/range?start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
     response.bodyString shouldBeJSON """{}"""
   }
@@ -86,48 +88,48 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   }
 
   "Retrieve /metrics/* with valid period and date" should "succeed" in {
-    val response = getHttpResponse(s"/metrics/$testEntityName?period=YEARLY&date=1960-01-01")
+    val response = getHttpResponse(s"/metrics/$testEntityName?period=YEARLY&date=$testStart")
     response.code.code should be (Ok.code)
     response.bodyString shouldBeJSON """{}"""
   }
 
   "Retrieve /metrics/*/series with no period" should "fail with error msg" in {
-    val response = awaitResponse(s"/metrics/$testEntName/series")
+    val response = getHttpResponse(s"/metrics/$testEntityName/series")
     response.code.code should be (BadRequest.code)
     response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter period required." } """
   }
 
   "Retrieve /metrics/*/series with no start" should "fail with error msg" in {
-    val response = awaitResponse(s"/metrics/$testEntName/series?period=YEARLY")
+    val response = getHttpResponse(s"/metrics/$testEntityName/series?period=YEARLY")
     response.code.code should be (BadRequest.code)
     response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter start required." } """
   }
 
   "Retrieve /metrics/*/series with no end" should "fail with error msg" in {
-    val response = awaitResponse(s"/metrics/$testEntName/series?period=YEARLY&start=1969-01-01")
+    val response = getHttpResponse(s"/metrics/$testEntityName/series?period=YEARLY&start=$testStart")
     response.code.code should be (BadRequest.code)
     response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter end required." } """
   }
 
   "Retrieve /metrics/*/series with period, start, and end" should "succeed" in {
-    val response = awaitResponse(s"/metrics/$testEntName/series?period=YEARLY&start=1969-01-01&end=1970-02-02")
+    val response = getHttpResponse(s"/metrics/$testEntityName/series?period=YEARLY&start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
   }
 
   "Retrieve /metrics/*/range with no start" should "fail with error msg" in {
-    val response = awaitResponse(s"/metrics/$testEntName/range")
+    val response = getHttpResponse(s"/metrics/$testEntityName/range")
     response.code.code should be (BadRequest.code)
     response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter start required." } """
   }
 
   "Retrieve /metrics/*/range with no end" should "fail with error msg" in {
-    val response = awaitResponse(s"/metrics/$testEntName/range?start=1969-01-01")
+    val response = getHttpResponse(s"/metrics/$testEntityName/range?start=$testStart")
     response.code.code should be (BadRequest.code)
     response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter end required." } """
   }
 
   "Retrieve /metrics/*/range with start and end" should "succeed" in {
-    val response = awaitResponse(s"/metrics/$testEntName/range?start=1969-01-01&end=1970-02-02")
+    val response = getHttpResponse(s"/metrics/$testEntityName/range?start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
   }
 
@@ -158,7 +160,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
 
   "Retrieve /metrics range after persisting" should "show persisted metrics" in {
     val expected = persistSingleMetric()
-    val response = getHttpResponse(s"metrics/$testEntityName/range?start=1969-01-01&end=1970-02-02")
+    val response = getHttpResponse(s"metrics/$testEntityName/range?start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
     response.bodyString shouldBeJSON expected
   }
@@ -166,16 +168,15 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
   "Retrieve /metrics range after persisting multiple metrics" should "show multiple persisted metrics" in {
     val metRange = 1 to 10
     val expected = persistManyMetrics(metRange)
-    val response = getHttpResponse(s"metrics/$testEntityName/range?start=1969-01-01&end=1970-02-02")
+    val response = getHttpResponse(s"metrics/$testEntityName/range?start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
-
     response.bodyString shouldBeJSON expected
   }
 
   "Retrieve /metrics series after persisting" should "show persisted metrics" in {
     val expectedMetric = persistSingleMetric()
 
-    val response = getHttpResponse(s"metrics/$testEntityName/series?period=MONTHLY&start=1969-12-01&end=1970-02-02")
+    val response = getHttpResponse(s"metrics/$testEntityName/series?period=MONTHLY&start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
 
     val expectSeries1 = """ { "start" : -2678400000, "end" : -1, "metrics" : { } } """
@@ -189,7 +190,7 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
     val metRange = 1 to 10
     val expectedMetrics = persistManyMetrics(metRange)
 
-    val response = getHttpResponse(s"metrics/$testEntityName/series?period=MONTHLY&start=1969-12-01&end=1970-02-02")
+    val response = getHttpResponse(s"metrics/$testEntityName/series?period=MONTHLY&start=$testStart&end=$testEnd")
     response.code.code should be (Ok.code)
 
     val expectSeries1 = """ { "start" : -2678400000, "end" : -1, "metrics" : { } } """

--- a/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
+++ b/balboa-http/src/it/scala/com/socrata/balboa/server/MetricsIntegrationTest.scala
@@ -91,6 +91,29 @@ class MetricsIntegrationTest extends FlatSpec with Matchers with BeforeAndAfterE
     response.bodyString shouldBeJSON """{}"""
   }
 
+  "Retrieve /metrics/*/series with no period" should "fail with error msg" in {
+    val response = awaitResponse(s"/metrics/$testEntName/series")
+    response.code.code should be (BadRequest.code)
+    response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter period required." } """
+  }
+
+  "Retrieve /metrics/*/series with no start" should "fail with error msg" in {
+    val response = awaitResponse(s"/metrics/$testEntName/series?period=YEARLY")
+    response.code.code should be (BadRequest.code)
+    response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter start required." } """
+  }
+
+  "Retrieve /metrics/*/series with no end" should "fail with error msg" in {
+    val response = awaitResponse(s"/metrics/$testEntName/series?period=YEARLY&start=1969-01-01")
+    response.code.code should be (BadRequest.code)
+    response.bodyString shouldBeJSON """ { "error": 400, "message": "Parameter end required." } """
+  }
+
+  "Retrieve /metrics/*/series with period, start, and end" should "succeed" in {
+    val response = awaitResponse(s"/metrics/$testEntName/series?period=YEARLY&start=1969-01-01&end=1970-02-02")
+    response.code.code should be (Ok.code)
+  }
+
   // Returns the JSON string representation of the metric added
   def persistSingleMetric(): String = {
     val metrics = new Metrics()


### PR DESCRIPTION
Note: protobuf response code tests purposefully left out of `/metrics/*/series` queries because the series endpoint does not support protobuf.