### PR TITLE
Quote mixed case keyspace names.

### DIFF
--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/Cassandra11Util.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/Cassandra11Util.scala
@@ -21,7 +21,18 @@ object Cassandra11Util extends StrictLogging {
   val leastGranular:Period = Period.leastGranular(periods)
   val mostGranular:Period = Period.mostGranular(periods)
 
-  case class DatastaxContext(cluster: Cluster, keyspace: String) {
+  case class DatastaxContext(cluster: Cluster, _keyspace: String) {
+    def keyspace = {
+      // Mixed case names are automatically lower cased somewhere along the
+      // way to Cassandra. So keyspaces that have mixed case names must be
+      // quoted to preserve case.
+      if (_keyspace != _keyspace.toLowerCase) {
+        '"' + _keyspace + '"'
+      } else {
+        _keyspace
+      }
+    }
+
     def newSession: Session = cluster.connect(keyspace)
   }
 

--- a/balboa-http/src/main/resources/config/config.properties
+++ b/balboa-http/src/main/resources/config/config.properties
@@ -30,9 +30,7 @@ memcached.servers = localhost:11211
 # Thrift API is deprecated and is being removed
 cassandra.servers = localhost:9042
 
-# Must use quotes to prevent automatic lowercasing of the keyspace name by
-# the Datastax driver
-cassandra.keyspace = "Metrics2012"
+cassandra.keyspace = Metrics2012
 
 cassandra.sotimeout = 1000
 cassandra.maxpoolsize = 50


### PR DESCRIPTION
Cassandra does not handle mixed case names well, and it would be better
if people never used mixed case names.

If the keyspace name is mixed case, quote it before passing it to the
Datastax driver.