### PR TITLE
Renamed Cassandra related classes.

### DIFF
--- a/balboa-core/src/main/java/com/socrata/balboa/metrics/data/DataStoreFactory.java
+++ b/balboa-core/src/main/java/com/socrata/balboa/metrics/data/DataStoreFactory.java
@@ -33,17 +33,17 @@ public class DataStoreFactory
         if (datastore.equals("buffered-cassandra")) {
             return new BufferedDataStore(
                     new BadIdeasDataStore(
-                            new Cassandra11DataStore(
-                                    new Cassandra11QueryImpl(
-                                            Cassandra11Util.initializeContext(conf)))));
+                            new CassandraDataStore(
+                                    new CassandraQueryImpl(
+                                            CassandraUtil.initializeContext(conf)))));
         }
 
         if (datastore.equals("cassandra"))
         {
             return new BadIdeasDataStore(
-                    new Cassandra11DataStore(
-                            new Cassandra11QueryImpl(
-                                    Cassandra11Util.initializeContext(conf))));
+                    new CassandraDataStore(
+                            new CassandraQueryImpl(
+                                    CassandraUtil.initializeContext(conf))));
         }
         else
         {

--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraQuery.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraQuery.scala
@@ -11,7 +11,7 @@ import scala.{collection => sc}
 /**
  * Queries the underlying datastore
  */
-trait Cassandra11Query {
+trait CassandraQuery {
   def getAllEntityIds(recordType:RecordType, period:Period):Iterator[String]
 
   def fetch(entityKey:String, period:Period, bucket:ju.Date):Metrics

--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraUtil.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraUtil.scala
@@ -16,7 +16,7 @@ import scala.{collection => sc}
 /**
  * Holds Connection Pool and Common ColumnFamily definitions
  */
-object Cassandra11Util extends StrictLogging {
+object CassandraUtil extends StrictLogging {
   val periods = Configuration.get().getSupportedPeriods
   val leastGranular:Period = Period.leastGranular(periods)
   val mostGranular:Period = Period.mostGranular(periods)
@@ -74,14 +74,14 @@ object Cassandra11Util extends StrictLogging {
       Iterator.empty
     }
   }
-  def sliceIterator(queryImpl:Cassandra11Query, entityId:String, period:Period, query:List[ju.Date]):Iterator[Timeslice] = {
+  def sliceIterator(queryImpl:CassandraQuery, entityId:String, period:Period, query:List[ju.Date]):Iterator[Timeslice] = {
     query.iterator.map { date =>
           val range = DateRange.create(period, date)
           new Timeslice(range.start.getTime, range.end.getTime, queryImpl.fetch(entityId, period, date))
     }.filter(_ != null)
   }
 
-  def metricsIterator(queryImpl: Cassandra11Query,
+  def metricsIterator(queryImpl: CassandraQuery,
                       entityId: String,
                       query: sc.Seq[(ju.Date, Period)]): Iterator[Metrics] = {
     {

--- a/balboa-core/src/test/scala/com/socrata/balboa/metrics/data/impl/CassandraDataStoreTest.scala
+++ b/balboa-core/src/test/scala/com/socrata/balboa/metrics/data/impl/CassandraDataStoreTest.scala
@@ -11,12 +11,9 @@ import org.junit.{Before, Ignore, Test}
 
 import scala.collection.JavaConverters._
 
-/**
- *
- */
-class Cassandra11DataStoreTest {
-  val mock = new MockCassandra11QueryImpl()
-  val cds: Cassandra11DataStore = new Cassandra11DataStore(mock)
+class CassandraDataStoreTest {
+  val mock = new MockCassandraQueryImpl()
+  val cds: CassandraDataStore = new CassandraDataStore(mock)
   val testMetrics: Metrics = new Metrics()
   val testEntity = "foo"
   val aggMetric = new Metric(Metric.RecordType.AGGREGATE, 1)
@@ -39,7 +36,7 @@ class Cassandra11DataStoreTest {
   @Test
   @Ignore("Requires a local cassandra server and should be executed in isolation")
   def testPersistIntegration(): Unit = {
-    val cds: Cassandra11DataStore = new Cassandra11DataStore()
+    val cds: CassandraDataStore = new CassandraDataStore()
     cds.persist(testEntity, System.currentTimeMillis(), testMetrics)
   }
 
@@ -223,11 +220,11 @@ class Cassandra11DataStoreTest {
     val expectedRanges = dr.toDates(requestPeriod).asScala.toList
 
     // Run it through the roll-up iterator
-    val tsItr = Cassandra11Util.sliceIterator(mock, "blah", supportedPeriod, inRanges)
-    val rdItr = Cassandra11Util.rollupSliceIterator(requestPeriod, tsItr)
+    val tsItr = CassandraUtil.sliceIterator(mock, "blah", supportedPeriod, inRanges)
+    val rdItr = CassandraUtil.rollupSliceIterator(requestPeriod, tsItr)
 
     // Pretend we support this period
-    val expectedItr = Cassandra11Util.sliceIterator(mock, "blah", requestPeriod, expectedRanges)
+    val expectedItr = CassandraUtil.sliceIterator(mock, "blah", requestPeriod, expectedRanges)
 
     // We can have more requested timeslices returned than if the query were natively supported
     // because
@@ -236,10 +233,9 @@ class Cassandra11DataStoreTest {
       val expect = expectedItr.next()
       requestPeriod match {
         case Period.MONTHLY => {}
-        case _ => {
+        case _ =>
           Assert.assertEquals("Expected start to be == rolledUp start",  expect.getStart, ts.getStart) // time slices do not have to exactly align on boundarys
           Assert.assertEquals("Expected end to be == rolledUp end",expect.getEnd, ts.getEnd)
-        }
       }
 
       Assert.assertTrue(DateRange.liesOnBoundary(new Date(ts.getStart), requestPeriod))
@@ -261,9 +257,9 @@ class Cassandra11DataStoreTest {
 
   @Test
   def rollUpSliceCrossOddBoundary() {
-    val start = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    val start = new GregorianCalendar(TimeZone.getTimeZone("UTC"))
     start.set(2010, 0, 12)
-    val end = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    val end = new GregorianCalendar(TimeZone.getTimeZone("UTC"))
     end.set(2010, 3, 16)
     rollUpIteratorTest(Period.MONTHLY, Period.WEEKLY, start.getTime.getTime, end.getTime.getTime)
   }

--- a/balboa-core/src/test/scala/com/socrata/balboa/metrics/data/impl/CassandraQueryImplTest.scala
+++ b/balboa-core/src/test/scala/com/socrata/balboa/metrics/data/impl/CassandraQueryImplTest.scala
@@ -13,11 +13,11 @@ import org.junit.{Ignore, Test}
 /**
  * Integration Test; Tests Ignored Manually
  */
-class Cassandra11QueryImplTest {
+class CassandraQueryImplTest {
   @Test
   @Ignore("Requires a local cassandra server and should be executed in isolation")
   def testFetchSet(): Unit = {
-    val q:Cassandra11Query = new Cassandra11QueryImpl(Cassandra11Util.initializeContext())
+    val q:CassandraQuery = new CassandraQueryImpl(CassandraUtil.initializeContext())
     q.persist("mykey", DateRange.create(Period.HOURLY,new Date(1000)).start, Period.HOURLY,
       Map("mymetric1" -> new Metric(RecordType.AGGREGATE, 1), "mymetric2" -> new Metric(RecordType.AGGREGATE, 555)),
       Map("mymetric3" -> new Metric(RecordType.ABSOLUTE, 666), "mymetric4" -> new Metric(RecordType.ABSOLUTE, 777)))
@@ -28,7 +28,7 @@ class Cassandra11QueryImplTest {
   @Test
   @Ignore("Requires a local cassandra server and should be executed in isolation")
   def testGetKeys(): Unit = {
-    val keysItr:Iterator[String] = new Cassandra11QueryImpl(Cassandra11Util.initializeContext()).getAllEntityIds(RecordType.AGGREGATE, Period.HOURLY)
+    val keysItr:Iterator[String] = new CassandraQueryImpl(CassandraUtil.initializeContext()).getAllEntityIds(RecordType.AGGREGATE, Period.HOURLY)
     keysItr.foreach(println)
   }
 
@@ -37,7 +37,7 @@ class Cassandra11QueryImplTest {
   def testConnectionFailureOnPersist() {
     BalboaFastFailCheck.getInstance().markSuccess()
     Configuration.get().setProperty("cassandra.servers", "example.test-socrata.com:12345")
-    val q:Cassandra11Query = new Cassandra11QueryImpl(Cassandra11Util.initializeContext())
+    val q:CassandraQuery = new CassandraQueryImpl(CassandraUtil.initializeContext())
     try {
       Assert.assertTrue(BalboaFastFailCheck.getInstance().proceed())
       q.persist("mykey", DateRange.create(Period.HOURLY,new Date(1000)).start, Period.HOURLY,
@@ -53,7 +53,7 @@ class Cassandra11QueryImplTest {
   def testConnectionFailureOnFetch() {
     BalboaFastFailCheck.getInstance().markSuccess()
     Configuration.get().setProperty("cassandra.servers", "example.test-socrata.com:12345")
-    val q:Cassandra11Query = new Cassandra11QueryImpl(Cassandra11Util.initializeContext())
+    val q:CassandraQuery = new CassandraQueryImpl(CassandraUtil.initializeContext())
     try {
       Assert.assertTrue(BalboaFastFailCheck.getInstance().proceed())
       q.fetch("mykey", Period.HOURLY, new DateRange(new Date(1000), new Date(2000)).start)
@@ -61,6 +61,5 @@ class Cassandra11QueryImplTest {
       Assert.assertTrue(BalboaFastFailCheck.getInstance().isInFailureMode)
     }
   }
-
 
 }

--- a/balboa-core/src/test/scala/com/socrata/balboa/metrics/data/impl/MockCassandraQueryImpl.scala
+++ b/balboa-core/src/test/scala/com/socrata/balboa/metrics/data/impl/MockCassandraQueryImpl.scala
@@ -8,10 +8,7 @@ import com.socrata.balboa.metrics.{Metric, Metrics}
 
 import scala.{collection => sc}
 
-/**
- *
- */
-class MockCassandra11QueryImpl extends Cassandra11Query {
+class MockCassandraQueryImpl extends CassandraQuery {
   var persists = List[APersist]()
   var fetches = List[AFetch]()
   var entities = List[AEntitySearch]()
@@ -25,14 +22,14 @@ class MockCassandra11QueryImpl extends Cassandra11Query {
   }
 
   def fetch(entityId:String, period:Period, bucket:Date):Metrics = {
-    val entityKey:String = Cassandra11Util.createEntityKey(entityId,bucket.getTime)
+    val entityKey:String = CassandraUtil.createEntityKey(entityId,bucket.getTime)
     //println("Fetching " + entityKey + " in period " + period + " DATE: " + bucket.toGMTString)
     fetches = fetches ::: List[AFetch](new AFetch(entityKey, period))
     metricsToReturn
   }
 
   def persist(entityId:String, bucket:Date, period:Period, aggregates:sc.Map[String, Metric], absolutes:sc.Map[String, Metric]) {
-    val entityKey:String = Cassandra11Util.createEntityKey(entityId,bucket.getTime)
+    val entityKey:String = CassandraUtil.createEntityKey(entityId,bucket.getTime)
     //println("Persisting " + entityKey + " in period " + period + " DATE: " + bucket.toGMTString)
     persists = persists ::: List[APersist](new APersist(entityKey, period, aggregates, absolutes))
   }
@@ -47,8 +44,8 @@ class APersist(val entityKey:String, val period:Period, val agg:sc.Map[String, M
     }
   }
 
-  override def toString():String = {
-    return "PERSIST: entityKey: " + entityKey + " period:" + period + " agg:" + agg + " abs:" + abs
+  override def toString:String = {
+    "PERSIST: entityKey: " + entityKey + " period:" + period + " agg:" + agg + " abs:" + abs
   }
 }
 
@@ -61,11 +58,11 @@ class AFetch(val entityKey:String, val period:Period) {
     }
   }
 
-  override def toString():String = {
-    return "FETCH: entityKey: " + entityKey + " period:" + period
+  override def toString:String = {
+    "FETCH: entityKey: " + entityKey + " period:" + period
   }
 }
 
 class AEntitySearch(val recordType:RecordType, val period:Period) extends Ordered[AEntitySearch]{
-  def compare(that:AEntitySearch) =  if (that.period.compareTo(this.period) == 0) (that.recordType.compareTo(this.recordType)) else that.period.compareTo(this.period)
+  def compare(that:AEntitySearch) =  if (that.period.compareTo(this.period) == 0) that.recordType.compareTo(this.recordType) else that.period.compareTo(this.period)
 }


### PR DESCRIPTION
It appears that Long Long Ago, someone named some Cassandra related classes with `11`, which I believe indicated Cassandra 1.1. That is no longer true, and will get less true as time goes on.