### PR TITLE
Fixed persisting of aggregate metrics

### DIFF
--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraQueryImpl.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraQueryImpl.scala
@@ -95,14 +95,29 @@ class CassandraQueryImpl(context: DatastaxContext) extends CassandraQuery with S
     val entityKey = CassandraUtil.createEntityKey(entityId, bucket.getTime)
     logger debug s"Using entity/row key $entityKey at period $period"
     fastfail.proceedOrThrow()
-
-    val batchStatement = new BatchStatement(BatchStatement.Type.LOGGED)
-
     val entityKeyWhere = QueryBuilder.eq("key", entityKey)
 
-    for (sameTypeRecords <- List(aggregates, absolutes).filter(_.nonEmpty)) {
+    for (sameTypeRecords <- List(absolutes, aggregates).filter(_.nonEmpty)) {
+      // Must execute counter and non-counter separately, since counter batches
+      // can only contain counter statements, and non-counter batches can only contain
+      // non-counter statements
+      //
+      // Beyond that, absolutes must go first so that the query doesn't fail
+      // after executing the non-idempotent part of the request (i.e. successfully
+      // increments aggregate but then fails to write absolute)
+
+      val recordType = sameTypeRecords.iterator.next()._2.getType
+
+      val batchStatement = new BatchStatement(
+        if (recordType == RecordType.AGGREGATE) {
+          BatchStatement.Type.COUNTER
+        } else {
+          BatchStatement.Type.LOGGED
+        }
+      )
+
       // Initialize the query to work with either AGGREGATE or ABSOLUTE type values
-      val table =  CassandraUtil.getColumnFamily(period, sameTypeRecords.iterator.next()._2.getType)
+      val table =  CassandraUtil.getColumnFamily(period, recordType)
 
       for {(k, v) <- sameTypeRecords} {
         if (k != "") {
@@ -121,19 +136,18 @@ class CassandraQueryImpl(context: DatastaxContext) extends CassandraQuery with S
           logger warn "dropping metric with empty string as column"
         }
       }
-    }
 
-    try {
-      context.execute(batchStatement)
-      fastfail.markSuccess()
-    } catch {
-      case e: Exception =>
-        val wrapped = new IOException("Error writing metrics " + entityKey + " from " + period, e)
-        fastfail.markFailure(wrapped)
-        logger.error(s"Error writing metrics $entityKey from $period", e)
-        throw wrapped
+      try {
+        context.execute(batchStatement)
+      } catch {
+        case e: Exception =>
+          val wrapped = new IOException("Error writing metrics " + entityKey + " from " + period, e)
+          fastfail.markFailure(wrapped)
+          logger.error(s"Error writing metrics $entityKey from $period", e)
+          throw wrapped
+      }
     }
+    fastfail.markSuccess()
   }
-
   val fastfail: BalboaFastFailCheck = BalboaFastFailCheck.getInstance
 }


### PR DESCRIPTION
This fixes a bug when attempting to persist a combined collection of aggregate and non-aggregate metrics. Aggregate metrics must be persisted through a separate query from non-aggregates, as they require a counter batch, while non-aggregates require a non-counter batch. See discussion [here](http://www.datastax.com/dev/blog/atomic-batches-in-cassandra-1-2) and [here](https://datastax-oss.atlassian.net/browse/NODEJS-158).