### PR TITLE
Update balboa-http integration tests

### DIFF
--- a/balboa-http/src/it/bash/integration-tests
+++ b/balboa-http/src/it/bash/integration-tests
@@ -176,18 +176,102 @@ function startServiceStack() {
   echo "balboa-http service is started."
 }
 
+function printUsage() {
+  echo
+  if [[ ! -z $1 ]]; then
+    echo "$1"
+    echo
+  fi
+  echo "$(basename $0) [--help] [-h <host-name> [-p <port>] | -c <config-file-name> ]"
+  echo
+  echo "    -h    the host name running the service to target the integration tests at."
+  echo "    -p    the port on the host to target the integration tests at. Defaults to 80."
+  echo "    -c    the name of the config file to source. Normally it would be something"
+  echo "          like 'staging' or 'rc'."
+  echo
+  echo "This script will also look for the ENVIRONMENT variable. If specified, it will"
+  echo "function the same as the -c parameter. If both the ENVIRONMENT variable and -c"
+  echo "are specified, -c takes precedence."
+  echo
+}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --help)
+      printUsage
+      exit
+      ;;
+    -h)
+      host="$2"
+      shift # past argument
+      if [[ -z $host ]]; then
+        printUsage "-h requires the host be specified."
+        exit 1
+      fi
+      ;;
+    -p)
+      port="$2"
+      shift # past argument
+      if [[ -z $port ]]; then
+        printUsage "-p requires the port be specified."
+        exit 1
+      fi
+      ;;
+    -c)
+      config_name="$2"
+      shift
+      if [[ -z $config_name ]]; then
+        printUsage "-c requires the config file name be specified."
+        exit 1
+      fi
+      ;;
+    *)
+      printUsage "Don't know what to do with '$key'."
+      exit 1
+      ;;
+  esac
+  shift # past argument or value
+done
+
+# If this script is executing inside Jenkins ($BUILD_NUMBER is defined), turn
+# off the colorization of the output so it doesn't obfuscate the build logs.
+[[ ! -z $BUILD_NUMBER ]] && SBT_OPTS="$SBT_OPTS -Dsbt.log.noformat=true"
+
+if [[ ! -z $config_name ]]; then
+  config_file=$(dirname $0)/$config_name.config
+elif [[ ! -z $ENVIRONMENT ]]; then
+  # This is the environment variable typically provided by the Jenkins job to
+  # indicate which environment the integration tests should execute against.
+  config_file=$(dirname $0)/$ENVIRONMENT.config
+fi
+if [[ ! -z $config_file ]]; then
+  if [[ ! -r $config_file ]]; then
+    echo "Unable to read the file '$config_file'."
+    exit 1
+  fi
+  source $config_file
+  SERVICE_PORT=${SERVICE_PORT:-80}
+fi
+if [[ ! -z $host ]]; then
+  SERVICE_HOST=$host
+  SERVICE_PORT=${port:-80}
+fi
+
 echo
 echo "************************************************************"
 echo " Starting balboa-http integration tests."
 echo
 
-startServiceStack
+if [[ -z $SERVICE_HOST ]]; then
+  startServiceStack
+fi
 
 # These environment variables are how the script communicates the balboa-http
 # endpoint to be targeted with the integration tests.
 export SERVICE_HOST
 export SERVICE_PORT
-echo "Running integration tests."
+echo "Running integration tests against '$SERVICE_HOST:$SERVICE_PORT'."
 sbt balboa-http/it:test
 rc=$?
 if [[ ! $rc -eq 0 ]]; then

--- a/balboa-http/src/it/bash/integration-tests
+++ b/balboa-http/src/it/bash/integration-tests
@@ -1,9 +1,17 @@
 #! /bin/bash
+#
+# This script coordinates the different pieces required to execute the
+# integration tests. It creates some Docker images, starts them, confirms they
+# are working, executes the integration tests then cleans up.
+#
+
 
 BALBOA_HTTP_PID=0
 
 DB_IMAGE_NAME=socrata-balboa-http-cassandra-${BUILD_NUMBER:-$RANDOM}
 
+# Modify this function to include all the necessary cleanup steps. Shutting
+# down supporting services, deleting temp files, so forth.
 function cleanUp() {
     echo
     echo "Shutting down the Cassandra Docker container. ($(docker stop $DB_IMAGE_NAME))"
@@ -23,13 +31,10 @@ function cleanUp() {
         echo
     fi
 }
-# Perform clean up activities under all circumstances (except kill -9) by
-# trapping the 'EXIT' pseudo-signal. Installing this signal handler means the
-# cleanUp function will be called whenever this script exits, even if
-# interrupted from the keyboard, 'kill'ed from the command line or exits
-# naturally at the end.
-trap cleanUp EXIT
 
+# Retry the passed in command until it succeeds, or the timeouts are exceeded.
+# If the timeouts are exceeded, the function will return 1. If the command is
+# eventually successful, the function will return 0.
 function waitForSuccess() {
   i=0
   while ! ( "$@" ) ; do
@@ -65,113 +70,129 @@ function getAvailableServicePort() {
     echo $PORT
 }
 
+function startServiceStack() {
+  if uname -a | grep Darwin >& /dev/null ; then
+    # On a Mac, look for the IP address of the VM docker-machine is using to run
+    # Docker containers.
+    eval $(docker-machine env)
+    dockerHost=$(docker-machine ip)
+    if [[ ! $? -eq 0 ]]; then
+      echo "Could not get the IP address of an active docker-machine instance."
+      echo "Use 'docker-machine ls' to confirm there is an active host."
+      exit 1
+    fi
+  else
+    # On Linux, look for the IP address associated with the 'docker' interface.
+    dockerHost=$(/sbin/ifconfig docker0 | sed '/inet addr:/!d;s|.*inet addr:\([^ ]*\).*|\1|')
+    if [[ -z $dockerHost ]]; then
+      echo "Could not find a docker network interface. Is Docker installed?"
+      exit 1
+    fi
+  fi
+
+  # Perform clean up activities under all circumstances (except kill -9) by
+  # trapping the 'EXIT' pseudo-signal. Installing this signal handler means the
+  # cleanUp function will be called whenever this script exits, even if
+  # interrupted from the keyboard, 'kill'ed from the command line or exits
+  # naturally at the end.
+  trap cleanUp EXIT
+
+  # Process the Cassandra schema template and replace the necessary variables
+  # with useful values.
+  SCHEMA_DIR=target/balboa-http-schema
+  mkdir -p $SCHEMA_DIR
+  sed "
+      s|{{datacenter-name}}|datacenter1|;
+      s|{{replication-factor}}|1|;
+  " etc/balboa-cassandra.cql > ${SCHEMA_DIR}/balboa-cassandra.cql
+
+  docker run \
+    -d \
+    --name $DB_IMAGE_NAME \
+    -p 9042/tcp \
+    -p 9160/tcp \
+    -v $(pwd)/${SCHEMA_DIR}:/balboa-schema \
+    cassandra:2.1
+
+  dbServerIp=$dockerHost
+  dbPort=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "9042/tcp") 0).HostPort }}' $DB_IMAGE_NAME)
+
+  echo "Looking for the Cassandra database on '$dbServerIp:$dbPort'"
+  if ! waitForSuccess nc -w 1 $dbServerIp $dbPort ; then
+    echo "Problem starting the database image."
+    echo "============================== Docker Logs: Database Image =============================="
+    docker logs $DB_IMAGE_NAME
+    exit 1
+  fi
+  echo "Database is started."
+
+  # Install the schema on the database.
+  echo "Installing the schema in the Cassandra database."
+  if ! docker exec $DB_IMAGE_NAME cassandra-cli -f /balboa-schema/balboa-cassandra.cql ; then
+    echo "Failed to install the Cassandra schema."
+    exit 1
+  fi
+
+  ORIGINAL_PROPERTIES_FILE=balboa-http/src/main/resources/config/config.properties
+  TEST_PROPERTIES_FILE="target/balboa-http-integrationtest-config-$$.properties"
+
+  export CASSANDRAS=$dbServerIp:$dbPort
+  echo "Writing temporary properties file to '$TEST_PROPERTIES_FILE'."
+  sed "
+      /^ *cassandra.servers[ =]/s|=.*|= $CASSANDRAS|
+  " $ORIGINAL_PROPERTIES_FILE > $TEST_PROPERTIES_FILE
+
+  # By adding a pre-compile step, the length of the compile does not add to the
+  # timeout around waiting for the service to start up. Using a separate step
+  # also allows for more explicit error reporting.
+  if ! sbt balboa-http/compile ; then
+      EXIT_MESSAGE="ERROR: balboa-http/compile failed."
+      exit 1
+  fi
+
+  # Make sure the log file exists so that if there will be no race condition
+  # where we grep for the success message before sbt gets started.
+  SERVICE_LOG=target/balboa-http-$$.log
+  touch $SERVICE_LOG
+  echo "Writing service log to '$SERVICE_LOG'"
+
+  # The dataset-of-datasets integration tests build a dockerized service for
+  # doing the testing, but making the dockerized service consumes a significant
+  # portion of the time for executing the integration tests. These tests run the
+  # service using sbt in the background to try to execute integration tests
+  # faster.
+  SERVICE_HOST=127.0.0.1
+  SERVICE_PORT=$(getAvailableServicePort)
+  sbt "balboa-http/run $SERVICE_PORT" "-Dbalboa.config=$TEST_PROPERTIES_FILE" >& $SERVICE_LOG &
+  BALBOA_HTTP_PID=$!
+
+  echo "Waiting for balboa-http to start on port '$SERVICE_HOST:$SERVICE_PORT'."
+  if ! waitForSuccess grep -q 'Starting balboa-http service' $SERVICE_LOG ; then
+    echo "Problem starting balboa-http service."
+    echo "============================== balboa-http service logs  =============================="
+    cat $SERVICE_LOG
+    exit 1
+  fi
+  echo "balboa-http service is started."
+}
+
 echo
 echo "************************************************************"
 echo " Starting balboa-http integration tests."
 echo
 
-if uname -a | grep Darwin >& /dev/null ; then
-  # On a Mac, look for the IP address of the VM docker-machine is using to run
-  # Docker containers.
-  eval $(docker-machine env)
-  dockerHost=$(docker-machine ip)
-  if [[ ! $? -eq 0 ]]; then
-    echo "Could not get the IP address of an active docker-machine instance."
-    echo "Use 'docker-machine ls' to confirm there is an active host."
-    exit 1
-  fi
-else
-  # On Linux, look for the IP address associated with the 'docker' interface.
-  dockerHost=$(/sbin/ifconfig docker0 | sed '/inet addr:/!d;s|.*inet addr:\([^ ]*\).*|\1|')
-  if [[ -z $dockerHost ]]; then
-    echo "Could not find a docker network interface. Is Docker installed?"
-    exit 1
-  fi
-fi
+startServiceStack
 
-# Process the Cassandra schema template and replace the necessary variables
-# with useful values.
-SCHEMA_DIR=target/balboa-http-schema
-mkdir -p $SCHEMA_DIR
-sed "
-    s|{{datacenter-name}}|datacenter1|;
-    s|{{replication-factor}}|1|;
-" etc/balboa-cassandra.cql > ${SCHEMA_DIR}/balboa-cassandra.cql
-
-docker run \
-  -d \
-  --name $DB_IMAGE_NAME \
-  -p 9042/tcp \
-  -p 9160/tcp \
-  -v $(pwd)/${SCHEMA_DIR}:/balboa-schema \
-  cassandra:2.1
-
-dbServerIp=$dockerHost
-dbPort=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "9042/tcp") 0).HostPort }}' $DB_IMAGE_NAME)
-
-echo "Looking for the database on $dbServerIp:$dbPort"
-if ! waitForSuccess nc -w 1 $dbServerIp $dbPort ; then
-  echo "Problem starting the database image."
-  echo "============================== Docker Logs: Database Image =============================="
-  docker logs $DB_IMAGE_NAME
-  exit 1
-fi
-echo "Database is started."
-
-# Install the schema on the database.
-echo "Installing the schema in the Cassandra database."
-if ! docker exec $DB_IMAGE_NAME cassandra-cli -f /balboa-schema/balboa-cassandra.cql ; then
-  echo "Failed to install the Cassandra schema."
-  exit 1
-fi
-
-ORIGINAL_PROPERTIES_FILE=balboa-http/src/main/resources/config/config.properties
-TEST_PROPERTIES_FILE="target/balboa-http-integrationtest-config-$$.properties"
-
-export CASSANDRAS=$dbServerIp:$dbPort
-echo "Writing temporary properties file to '$TEST_PROPERTIES_FILE'."
-sed "
-    /^ *cassandra.servers[ =]/s|=.*|= $CASSANDRAS|
-" $ORIGINAL_PROPERTIES_FILE > $TEST_PROPERTIES_FILE
-
-# By adding a pre-compile step, the length of the compile does not add to the
-# timeout around waiting for the service to start up. Using a separate step
-# also allows for more explicit error reporting.
-if ! sbt balboa-http/compile ; then
-    EXIT_MESSAGE="ERROR: balboa-http/compile failed."
-    exit 1
-fi
-
-# Make sure the log file exists so that if there will be no race condition
-# where we grep for the success message before sbt gets started.
-SERVICE_LOG=target/balboa-http-$$.log
-touch $SERVICE_LOG
-echo "Writing service log to '$SERVICE_LOG'"
-
-# The dataset-of-datasets integration tests build a dockerized service for
-# doing the testing, but making the dockerized service consumes a significant
-# portion of the time for executing the integration tests. These tests run the
-# service using sbt in the background to try to execute integration tests
-# faster.
-SERVICE_PORT=$(getAvailableServicePort)
-sbt "balboa-http/run $SERVICE_PORT" "-Dbalboa.config=$TEST_PROPERTIES_FILE" >& $SERVICE_LOG &
-BALBOA_HTTP_PID=$!
-
-echo "Waiting for balboa-http to start on port $SERVICE_PORT."
-if ! waitForSuccess grep -q 'Starting balboa-http service' $SERVICE_LOG ; then
-  echo "Problem starting balboa-http service."
-  echo "============================== balboa-http service logs  =============================="
-  cat $SERVICE_LOG
-  exit 1
-fi
-echo "balboa-http service is started."
-
+# These environment variables are how the script communicates the balboa-http
+# endpoint to be targeted with the integration tests.
+export SERVICE_HOST
+export SERVICE_PORT
 echo "Running integration tests."
-export SERVICE_PORT  # So it is available for integration test configuration.
 sbt balboa-http/it:test
 rc=$?
 if [[ ! $rc -eq 0 ]]; then
-  echo "============================== balboa-http service logs  =============================="
+  echo "============================== balboa-http service logs : start =============================="
   cat $SERVICE_LOG
+  echo "=============================== balboa-http service logs : end ==============================="
 fi
 exit $rc

--- a/balboa-http/src/it/bash/integration-tests
+++ b/balboa-http/src/it/bash/integration-tests
@@ -2,7 +2,13 @@
 
 BALBOA_HTTP_PID=0
 
+DB_IMAGE_NAME=socrata-balboa-http-cassandra-${BUILD_NUMBER:-$RANDOM}
+
 function cleanUp() {
+    echo
+    echo "Shutting down the Cassandra Docker container. ($(docker stop $DB_IMAGE_NAME))"
+    echo "Removing the Cassandra Docker container. ($(docker rm -v $DB_IMAGE_NAME))"
+
     if [[ $BALBOA_HTTP_PID -gt 0 ]]; then
         echo "Stopping balboa-http."
         # The balboa-http is running with sbt, so balboa-http itself is
@@ -24,13 +30,20 @@ function cleanUp() {
 # naturally at the end.
 trap cleanUp EXIT
 
-
-function getCassandraSeedNodes() {
-    case $ENVIRONMENT in
-        *)
-            echo "localhost:9042"
-            ;;
-    esac
+function waitForSuccess() {
+  i=0
+  while ! ( "$@" ) ; do
+    sleep 1
+    ((i++))
+    if [[ $i -eq 300 ]]; then
+      echo
+      echo "Timed out waiting for service to become healthy."
+      echo
+      return 1
+    fi
+  done
+  echo
+  return 0
 }
 
 function getAvailableServicePort() {
@@ -57,17 +70,69 @@ echo "************************************************************"
 echo " Starting balboa-http integration tests."
 echo
 
+if uname -a | grep Darwin >& /dev/null ; then
+  # On a Mac, look for the IP address of the VM docker-machine is using to run
+  # Docker containers.
+  eval $(docker-machine env)
+  dockerHost=$(docker-machine ip)
+  if [[ ! $? -eq 0 ]]; then
+    echo "Could not get the IP address of an active docker-machine instance."
+    echo "Use 'docker-machine ls' to confirm there is an active host."
+    exit 1
+  fi
+else
+  # On Linux, look for the IP address associated with the 'docker' interface.
+  dockerHost=$(/sbin/ifconfig docker0 | sed '/inet addr:/!d;s|.*inet addr:\([^ ]*\).*|\1|')
+  if [[ -z $dockerHost ]]; then
+    echo "Could not find a docker network interface. Is Docker installed?"
+    exit 1
+  fi
+fi
+
+# Process the Cassandra schema template and replace the necessary variables
+# with useful values.
+SCHEMA_DIR=target/balboa-http-schema
+mkdir -p $SCHEMA_DIR
+sed "
+    s|{{datacenter-name}}|datacenter1|;
+    s|{{replication-factor}}|1|;
+" etc/balboa-cassandra.cql > ${SCHEMA_DIR}/balboa-cassandra.cql
+
+docker run \
+  -d \
+  --name $DB_IMAGE_NAME \
+  -p 9042/tcp \
+  -p 9160/tcp \
+  -v $(pwd)/${SCHEMA_DIR}:/balboa-schema \
+  cassandra:2.1
+
+dbServerIp=$dockerHost
+dbPort=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "9042/tcp") 0).HostPort }}' $DB_IMAGE_NAME)
+
+echo "Looking for the database on $dbServerIp:$dbPort"
+if ! waitForSuccess nc -w 1 $dbServerIp $dbPort ; then
+  echo "Problem starting the database image."
+  echo "============================== Docker Logs: Database Image =============================="
+  docker logs $DB_IMAGE_NAME
+  exit 1
+fi
+echo "Database is started."
+
+# Install the schema on the database.
+echo "Installing the schema in the Cassandra database."
+if ! docker exec $DB_IMAGE_NAME cassandra-cli -f /balboa-schema/balboa-cassandra.cql ; then
+  echo "Failed to install the Cassandra schema."
+  exit 1
+fi
+
 ORIGINAL_PROPERTIES_FILE=balboa-http/src/main/resources/config/config.properties
 TEST_PROPERTIES_FILE="target/balboa-http-integrationtest-config-$$.properties"
 
-export CASSANDRAS=$(getCassandraSeedNodes)
+export CASSANDRAS=$dbServerIp:$dbPort
 echo "Writing temporary properties file to '$TEST_PROPERTIES_FILE'."
 sed "
     /^ *cassandra.servers[ =]/s|=.*|= $CASSANDRAS|
 " $ORIGINAL_PROPERTIES_FILE > $TEST_PROPERTIES_FILE
-
-SERVICE_LOG=target/balboa-http-$$.log
-echo "Writing service log to '$SERVICE_LOG'"
 
 # By adding a pre-compile step, the length of the compile does not add to the
 # timeout around waiting for the service to start up. Using a separate step
@@ -77,31 +142,36 @@ if ! sbt balboa-http/compile ; then
     exit 1
 fi
 
-SERVICE_PORT=$(getAvailableServicePort)
+# Make sure the log file exists so that if there will be no race condition
+# where we grep for the success message before sbt gets started.
+SERVICE_LOG=target/balboa-http-$$.log
+touch $SERVICE_LOG
+echo "Writing service log to '$SERVICE_LOG'"
+
 # The dataset-of-datasets integration tests build a dockerized service for
 # doing the testing, but making the dockerized service consumes a significant
 # portion of the time for executing the integration tests. These tests run the
 # service using sbt in the background to try to execute integration tests
 # faster.
+SERVICE_PORT=$(getAvailableServicePort)
 sbt "balboa-http/run $SERVICE_PORT" "-Dbalboa.config=$TEST_PROPERTIES_FILE" >& $SERVICE_LOG &
 BALBOA_HTTP_PID=$!
 
-echo -n "Waiting for balboa-http to start on port $SERVICE_PORT."
-i=0
-while ! grep "Starting balboa-http service" $SERVICE_LOG >& /dev/null ; do
-    sleep 1
-    i=$((i + 1))
-    echo -n "."
-
-    if [[ $i -eq 20 ]]; then
-        echo
-        EXIT_MESSAGE="ERROR: It appears that the balboa-http never started."
-        exit 1
-    fi
-done
-echo
+echo "Waiting for balboa-http to start on port $SERVICE_PORT."
+if ! waitForSuccess grep -q 'Starting balboa-http service' $SERVICE_LOG ; then
+  echo "Problem starting balboa-http service."
+  echo "============================== balboa-http service logs  =============================="
+  cat $SERVICE_LOG
+  exit 1
+fi
 echo "balboa-http service is started."
 
 echo "Running integration tests."
 export SERVICE_PORT  # So it is available for integration test configuration.
 sbt balboa-http/it:test
+rc=$?
+if [[ ! $rc -eq 0 ]]; then
+  echo "============================== balboa-http service logs  =============================="
+  cat $SERVICE_LOG
+fi
+exit $rc

--- a/balboa-http/src/it/bash/rc.config
+++ b/balboa-http/src/it/bash/rc.config
@@ -1,0 +1,1 @@
+SERVICE_HOST=balboa.app.aws-us-west-2-rc.socrata.net

--- a/balboa-http/src/it/bash/staging.config
+++ b/balboa-http/src/it/bash/staging.config
@@ -1,0 +1,1 @@
+SERVICE_HOST=balboa.app.aws-us-west-2-staging.socrata.net

--- a/etc/balboa-cassandra.cql
+++ b/etc/balboa-cassandra.cql
@@ -1,14 +1,25 @@
 --
+-- This file is a TEMPLATE of the schema of the balboa-http Cassandra database.
+-- A couple of items need to be replaced with legal values in order for this
+-- template to be usable.
+--
+-- In the very first statement, replace:
+--     {{datacenter-name}}
+--     {{replication-factor}}
+-- Reasonable defaults are:
+--     datacenter1
+--     1
+--
 -- A schema definition of the keyspace and it's contents used by balboa for
 -- recording metric data.
 --
--- The first query needs the correct data center to be filled in before this
--- file is executed.
+-- This file only works with the `cassandra-cli` command line utility. That
+-- utility is deprecated and due to be removed from Cassandra in 2.2. This
+-- schema will have to be ported to cqlsh to upgrade to that release.
 --
-
 create keyspace Metrics2012
   with placement_strategy = 'NetworkTopologyStrategy'
-  and strategy_options = {<- FILL IN WITH DATACENTER -> : 3}
+  and strategy_options = { {{datacenter-name}} : {{replication-factor}} }
   and durable_writes = true;
 
 use Metrics2012;

--- a/jenkins/integration-tests
+++ b/jenkins/integration-tests
@@ -1,9 +1,14 @@
 #! /bin/bash
+#
+# This script is the entry point to execute all the integration tests for this
+# repository. It is executed by a Jenkins job on each pull request.
+#
 
+# The balboa-agent integration tests exist but don't yet have the necessary
+# functionality to start up ActiveMQ, so for the moment they are removed from
+# this script, which is run by Jenkins as part of every pull request.
 # Right now the `balboa-agent` integration tests, when executed on Jenkins,
 # hang looking for the ActiveMQ server to remove the queue from during clean
 # up. As an emergency step, I'm disabling those tests for the moment.
 #balboa-agent/src/it/bash/integration-tests
-
-# Disabling the balboa-http tests pending the merge of the branch that makes them go.
-#balboa-http/src/it/bash/integration-tests
+balboa-http/src/it/bash/integration-tests


### PR DESCRIPTION
Add support for starting a Docker container with a Cassandra instance,
importing the necessary schema and connecting balboa-http to the
instance for the integration tests.