### PR TITLE
Switch from scala-logging-slf4j to updated version scala-logging

### DIFF
--- a/balboa-agent/src/it/scala/com/socrata/balboa/agent/RemoveQueue.scala
+++ b/balboa-agent/src/it/scala/com/socrata/balboa/agent/RemoveQueue.scala
@@ -2,7 +2,7 @@ package com.socrata.balboa.agent
 
 import javax.jms.{ExceptionListener, JMSException, Session}
 
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.activemq.command.ActiveMQDestination
 import org.apache.activemq.{ActiveMQConnection, ActiveMQConnectionFactory}
 

--- a/balboa-agent/src/main/scala/com/socrata/balboa/agent/BalboaAgent.scala
+++ b/balboa-agent/src/main/scala/com/socrata/balboa/agent/BalboaAgent.scala
@@ -8,7 +8,7 @@ import com.codahale.metrics.JmxReporter
 import com.socrata.balboa.agent.metrics.BalboaAgentMetrics
 import com.socrata.balboa.util.FileUtils
 import com.socrata.metrics.MetricQueue
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.activemq.{ActiveMQConnection, ActiveMQConnectionFactory}
 
 import util.control.NonFatal

--- a/balboa-agent/src/main/scala/com/socrata/balboa/agent/HttpMetricQueue.scala
+++ b/balboa-agent/src/main/scala/com/socrata/balboa/agent/HttpMetricQueue.scala
@@ -8,7 +8,7 @@ import com.socrata.metrics.{IdParts, MetricQueue}
 import com.stackmob.newman.dsl.POST
 import com.stackmob.newman.response.HttpResponseCode.Ok
 import com.stackmob.newman.{ApacheHttpClient, HttpClient}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.json4s.jackson.JsonMethods.{pretty, render}
 import org.json4s.{DefaultFormats, Extraction, Formats}
 

--- a/balboa-agent/src/main/scala/com/socrata/balboa/agent/LoggingTransportListener.scala
+++ b/balboa-agent/src/main/scala/com/socrata/balboa/agent/LoggingTransportListener.scala
@@ -2,7 +2,7 @@ package com.socrata.balboa.agent
 
 import java.io.IOException
 
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.activemq.transport.TransportListener
 
 class LoggingTransportListener extends TransportListener with StrictLogging {

--- a/balboa-agent/src/main/scala/com/socrata/balboa/agent/MetricFileProvider.scala
+++ b/balboa-agent/src/main/scala/com/socrata/balboa/agent/MetricFileProvider.scala
@@ -3,7 +3,7 @@ package com.socrata.balboa.agent
 import java.io.File
 import java.nio.file.Path
 import com.socrata.balboa.util.FileUtils
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import scala.collection.JavaConverters._
 
 /**

--- a/balboa-agent/src/main/scala/com/socrata/balboa/agent/metrics/BalboaAgentMetrics.scala
+++ b/balboa-agent/src/main/scala/com/socrata/balboa/agent/metrics/BalboaAgentMetrics.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics._
 import com.socrata.balboa.util.FileUtils
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.{Failure, Success, Try}
 

--- a/balboa-agent/src/test/scala/com/socrata/balboa/agent/HttpMetricQueueSpec.scala
+++ b/balboa-agent/src/test/scala/com/socrata/balboa/agent/HttpMetricQueueSpec.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.socrata.balboa.metrics.Metric.RecordType
 import com.socrata.metrics.{DomainId, MetricIdParts, UserUid, ViewUid}
 import com.stackmob.newman.{ApacheHttpClient, Headers, RawBody}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.mockito.ArgumentCaptor
 import org.scalatest.{BeforeAndAfterEach, ShouldMatchers, WordSpec}
 import org.mockito.Mockito._

--- a/balboa-agent/src/test/scala/com/socrata/balboa/agent/MetricConsumerSpec.scala
+++ b/balboa-agent/src/test/scala/com/socrata/balboa/agent/MetricConsumerSpec.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Files, Path}
 import com.blist.metrics.impl.queue.MetricFileQueue
 import com.socrata.balboa.metrics.Metric
 import com.socrata.metrics.{Fluff, MetricIdParts, MetricQueue}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.mockito.Matchers
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ShouldMatchers, WordSpec}

--- a/balboa-client-jms/src/main/scala/com/socrata/balboa/impl/ActiveMessageQueue.scala
+++ b/balboa-client-jms/src/main/scala/com/socrata/balboa/impl/ActiveMessageQueue.scala
@@ -4,13 +4,11 @@ import javax.jms.Session
 
 import com.socrata.balboa.metrics.Message
 import com.socrata.metrics.components.{EmergencyFileWriterComponent, MessageQueueComponent}
-import com.typesafe.scalalogging.slf4j.Logger
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.activemq.ActiveMQConnectionFactory
-import org.slf4j.LoggerFactory
 
-trait ActiveMQueueComponent extends MessageQueueComponent {
+trait ActiveMQueueComponent extends MessageQueueComponent with StrictLogging {
   self: ServerInformation with EmergencyFileWriterComponent =>
-  private val log: Logger = Logger(LoggerFactory.getLogger(this.getClass))
 
   class MessageQueue extends MessageQueueLike {
     val factory = new ActiveMQConnectionFactory(activeServer)
@@ -25,7 +23,7 @@ trait ActiveMQueueComponent extends MessageQueueComponent {
     def stop(): Unit = {
       connection.close()
       fileWriter.close()
-      log.info("Shutdown BalboaClient")
+      logger info "Shutdown BalboaClient"
     }
 
     def send(msg:Message): Unit = {
@@ -33,7 +31,7 @@ trait ActiveMQueueComponent extends MessageQueueComponent {
         producer.send(session.createTextMessage(new String(msg.serialize())))
       } catch {
         case e:Exception =>
-          log.error("Sending message to ActiveMQ failed (see previous error); writing message to file " + backupFile, e)
+          logger.error("Sending message to ActiveMQ failed (see previous error); writing message to file " + backupFile, e)
           fileWriter.send(msg)
       }
     }

--- a/balboa-client-jms/src/main/scala/com/socrata/balboa/impl/ActiveMessageQueue.scala
+++ b/balboa-client-jms/src/main/scala/com/socrata/balboa/impl/ActiveMessageQueue.scala
@@ -4,11 +4,13 @@ import javax.jms.Session
 
 import com.socrata.balboa.metrics.Message
 import com.socrata.metrics.components.{EmergencyFileWriterComponent, MessageQueueComponent}
-import com.typesafe.scalalogging.StrictLogging
 import org.apache.activemq.ActiveMQConnectionFactory
+import org.slf4j.LoggerFactory
 
-trait ActiveMQueueComponent extends MessageQueueComponent with StrictLogging {
+trait ActiveMQueueComponent extends MessageQueueComponent {
   self: ServerInformation with EmergencyFileWriterComponent =>
+
+  val logger = LoggerFactory.getLogger(this.getClass)
 
   class MessageQueue extends MessageQueueLike {
     val factory = new ActiveMQConnectionFactory(activeServer)

--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/BadIdeasDataStore.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/BadIdeasDataStore.scala
@@ -4,7 +4,7 @@ import java.{util => ju}
 
 import com.socrata.balboa.metrics.{Metrics, Timeslice}
 import com.socrata.balboa.metrics.data.{DataStore, Period}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.JavaConverters._
 

--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraDataStore.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraDataStore.scala
@@ -6,7 +6,7 @@ import com.socrata.balboa.metrics.Metric.RecordType
 import com.socrata.balboa.metrics.config.Configuration
 import com.socrata.balboa.metrics.data.{DateRange, Period, QueryOptimizer}
 import com.socrata.balboa.metrics.{Metric, Metrics, Timeslice}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.JavaConverters._
 

--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraQueryImpl.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraQueryImpl.scala
@@ -9,7 +9,7 @@ import com.socrata.balboa.metrics.Metric.RecordType
 import com.socrata.balboa.metrics.data.impl.CassandraUtil.DatastaxContext
 import com.socrata.balboa.metrics.data.{BalboaFastFailCheck, Period}
 import com.socrata.balboa.metrics.{Metric, Metrics}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.{collection => sc}
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter

--- a/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraUtil.scala
+++ b/balboa-core/src/main/scala/com/socrata/balboa/metrics/data/impl/CassandraUtil.scala
@@ -8,7 +8,7 @@ import com.socrata.balboa.metrics.Metric.RecordType
 import com.socrata.balboa.metrics.{Metrics, Timeslice}
 import com.socrata.balboa.metrics.config.Configuration
 import com.socrata.balboa.metrics.data.{DateRange, Period}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import com.datastax.driver.core._
 
 import scala.util.Try

--- a/balboa-http/src/main/scala/ScalatraBootstrap.scala
+++ b/balboa-http/src/main/scala/ScalatraBootstrap.scala
@@ -1,7 +1,7 @@
 import javax.servlet.ServletContext
 
 import com.socrata.balboa.server.{HealthCheckServlet, MainServlet, MetricsServlet}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.scalatra.LifeCycle
 import org.scalatra.metrics.MetricsBootstrap
 

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/ClientCounter.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/ClientCounter.scala
@@ -2,7 +2,7 @@ package com.socrata.balboa.server
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.scalatra.ScalatraServlet
 
 trait ClientCounter extends ScalatraServlet with StrictLogging {

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/Main.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/Main.scala
@@ -1,6 +1,6 @@
 package com.socrata.balboa.server
 
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.webapp.WebAppContext
 import org.scalatra.servlet.ScalatraListener

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/MainServlet.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/MainServlet.scala
@@ -6,7 +6,7 @@ import com.socrata.balboa.BuildInfo
 import com.socrata.balboa.metrics.data.BalboaFastFailCheck
 import com.socrata.balboa.server.rest.EntitiesRest
 import com.socrata.balboa.server.ResponseWithType.json
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.{InternalServerError, Ok, ScalatraServlet}
 import org.scalatra.json.JacksonJsonSupport

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/MetricsServlet.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/MetricsServlet.scala
@@ -9,7 +9,7 @@ import com.socrata.balboa.metrics.{Metric, Metrics}
 import com.socrata.balboa.server.ResponseWithType._
 import com.socrata.balboa.server.ScalatraUtil.getAccepts
 import com.socrata.balboa.server.rest.Extractable
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.codehaus.jackson.map.annotate.JsonSerialize
 import org.codehaus.jackson.map.{ObjectMapper, SerializationConfig}
 import org.scalatra.metrics.MetricsSupport

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/UnexpectedErrorFilter.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/UnexpectedErrorFilter.scala
@@ -1,7 +1,7 @@
 package com.socrata.balboa.server
 
 import com.socrata.balboa.server.ResponseWithType.json
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 import org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500
 import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.{InternalServerError, ScalatraServlet}

--- a/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/BalboaKafkaConsumerCLI.scala
+++ b/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/BalboaKafkaConsumerCLI.scala
@@ -5,10 +5,9 @@ import java.util.Properties
 import com.socrata.balboa.metrics.Message
 import com.socrata.balboa.metrics.data.{DataStore, DataStoreFactory}
 import com.socrata.balboa.service.kafka.consumer.{BalboaConsumerGroup, KafkaConsumerGroupComponent}
-import com.typesafe.scalalogging.slf4j.Logger
+import com.typesafe.scalalogging.StrictLogging
 import joptsimple.OptionSet
 import kafka.consumer.{Consumer, ConsumerConfig}
-import org.slf4j.LoggerFactory
 
 /**
  * Balboa Kafka Main Application:
@@ -16,9 +15,7 @@ import org.slf4j.LoggerFactory
  * Entry point for Balboa Kafka Consumer.  This application starts a service that listens
  * on a configurable list of ZooKeeper Host Ports.  This service currently listens for all published Tenant Metrics.
  */
-object BalboaKafkaConsumerCLI extends KafkaConsumerCLIBase[String, Message] {
-
-  private val Log = LoggerFactory.getLogger(this.getClass)
+object BalboaKafkaConsumerCLI extends KafkaConsumerCLIBase[String, Message] with StrictLogging {
 
   private val TOPIC_PERSISTENT_CONSUMER_WAITTIME_KEY = "balboa.kafka.consumer.persistent.waittime"
   private val CASSANDRA_SERVERS_KEY = "cassandra.servers"
@@ -43,12 +40,12 @@ object BalboaKafkaConsumerCLI extends KafkaConsumerCLIBase[String, Message] {
   /** See [[KafkaConsumerCLIBase.consumerGroup()]] */
   override def consumerGroup(): KafkaConsumerGroupComponent[String, Message] = {
     val config = new ConsumerConfig(properties.props)
-    Log.info(s"Creating consumer connector...")
+    logger info s"Creating consumer connector..."
     val cc = Consumer.create(config)
-    Log.info(s"Created consumer connector: $cc")
-    Log.info(s"Creating Balboa Consumer Group...")
+    logger info s"Created consumer connector: $cc"
+    logger info s"Creating Balboa Consumer Group..."
     val g = new BalboaConsumerGroup(cc, topic, partitions, ds, waitTime, retries)
-    Log.info(s"Group $g created")
+    logger info s"Group $g created"
     g
   }
 

--- a/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/consumer/BalboaConsumerGroup.scala
+++ b/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/consumer/BalboaConsumerGroup.scala
@@ -4,7 +4,7 @@ import com.socrata.balboa.common.kafka.codec.{BalboaMessageCodec, StringCodec}
 import com.socrata.balboa.metrics.Message
 import com.socrata.balboa.metrics.data.DataStore
 import kafka.consumer.{Consumer, ConsumerConfig, ConsumerConnector, KafkaStream}
-import com.typesafe.scalalogging.slf4j.StrictLogging
+import com.typesafe.scalalogging.StrictLogging
 
 /**
  * A [[KafkaConsumerGroupComponent[String, Message]] that is meant to handle Balboa specific Kafka message traffic.

--- a/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/consumer/PersistentKafkaConsumerComponent.scala
+++ b/balboa-service-kafka/src/main/scala/com/socrata/balboa/service/kafka/consumer/PersistentKafkaConsumerComponent.scala
@@ -3,8 +3,7 @@ package com.socrata.balboa.service.kafka.consumer
 import java.io.IOException
 
 import com.socrata.balboa.metrics.data.BalboaFastFailCheck
-import com.typesafe.scalalogging.slf4j.Logger
-import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.StrictLogging
 
 trait PersistentKafkaConsumerReadiness extends KafkaConsumerReadiness {
 
@@ -24,10 +23,8 @@ trait PersistentKafkaConsumerReadiness extends KafkaConsumerReadiness {
  */
 trait PersistentKafkaConsumerComponent[K,M] extends KafkaConsumerComponent[K,M] {
 
-  trait PersistentKafkaConsumer extends KafkaConsumer {
+  trait PersistentKafkaConsumer extends KafkaConsumer with StrictLogging {
     self: KafkaConsumerStreamProvider[K,M] with PersistentKafkaConsumerReadiness =>
-
-    private val Log = Logger(LoggerFactory getLogger this.getClass)
 
     /**
      * Attempt to persist a message.
@@ -49,7 +46,7 @@ trait PersistentKafkaConsumerComponent[K,M] extends KafkaConsumerComponent[K,M] 
       // As an effect, Having the node or killing the service will potentially result in a message loss
       
       if(attempts >= retries) {
-        Log.error("Exceeded allowed number of retries")
+        logger error "Exceeded allowed number of retries"
         throw new IOException("Exceeded allowed number of retries")
       }
 
@@ -64,7 +61,7 @@ trait PersistentKafkaConsumerComponent[K,M] extends KafkaConsumerComponent[K,M] 
           waitUntilReady()
           consume(key, message, attempts + 1)
         case e: Exception =>
-          Log.error(s"Unable to persist Kafka Key-Message: $key-$message.", e)
+          logger error(s"Unable to persist Kafka Key-Message: $key-$message.", e)
           val errorMessage = e.getMessage
           Some(s"Unable to persist Kafka Key-Message: $key-$message..  Reason: $errorMessage")
       }

--- a/project/BalboaAgent.scala
+++ b/project/BalboaAgent.scala
@@ -32,5 +32,5 @@ object BalboaAgent extends DockerKeys with LinuxKeys {
     scalatest,
     typesafe_config,
     json4s
-  )
+  ) ++ balboa_logging
 }

--- a/project/BalboaCommon.scala
+++ b/project/BalboaCommon.scala
@@ -12,6 +12,10 @@ object BalboaCommon {
   )
 
   def libraries(implicit scalaVersion: String) = Seq(
+    // SLF4J is used directly here instead of scala-logging to allow for cross-compilation to 2.10
+    log4j,
+    slf4j_log4j,
+
     junit,
     protobuf_java,
     mockito_test,
@@ -19,7 +23,7 @@ object BalboaCommon {
     jackson_mapper_asl,
     jopt_simple,
     json4s
-  ) ++ balboa_logging
+  )
 }
 
 object BalboaKafkaCommon {

--- a/project/BalboaCore.scala
+++ b/project/BalboaCore.scala
@@ -17,5 +17,5 @@ object BalboaCore {
     log4j,
     java_nullable_annotation,
     junit
-  )
+  ) ++ balboa_logging
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val opencsv = "2.0.1"
     val protobuf_java = "2.3.0"
     val rojoma_json = "[2.1.0, 3.0.0)"
-    val scala_logging = "2.1.2"
+    val scala_logging = "3.4.0"
     val slf4j_log4j = "1.7.12"
     val scopt = "3.3.0"
     val simple_arm = "[1.1.10, 2.0.0)"
@@ -38,7 +38,7 @@ object Dependencies {
   //////////////////////////////////////////////////////////////////
 
   // Logging Abstraction Layer for Scala and Java.  Using SLF4J
-  val scala_logging = "com.typesafe.scala-logging" %% "scala-logging-slf4j" % versions.scala_logging
+  val scala_logging = "com.typesafe.scala-logging" %% "scala-logging" % versions.scala_logging
   // Logging SLF4J binding to Log4J
   val slf4j_log4j = "org.slf4j" % "slf4j-log4j12" % versions.slf4j_log4j
   // Underlying Log4J library


### PR DESCRIPTION
This is a blocker for getting Gatling load testing integrated into balboa, as Gatling depends on scala-logging which is incorrectly resolved when scala-logging-slf4j is included.