### PR TITLE
Stop setting the JMX port.

### DIFF
--- a/balboa-http/docker/Dockerfile
+++ b/balboa-http/docker/Dockerfile
@@ -2,8 +2,7 @@ FROM socrata/runit-java8
 
 # Forward the ZooKeeper and Cassandra Port.
 ENV BALBOA_PORT 2012
-ENV JMX_PORT 40506
-EXPOSE $BALBOA_PORT $JMX_PORT
+EXPOSE $BALBOA_PORT
 
 ### Environment Variables
 ENV APP balboa-http

--- a/balboa-http/docker/run
+++ b/balboa-http/docker/run
@@ -10,9 +10,6 @@ set -ev
 exec su socrata -c '/usr/bin/java \
     -Xmx${JAVA_XMX} \
     -Xms${JAVA_XMX} \
-    -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
-    -Dcom.sun.management.jmxremote.ssl=false \
-    -Dcom.sun.management.jmxremote.authenticate=false \
     -Dbalboa.config=${BALBOA_CONFIG} \
     -Dlog4j.configuration=${BALBOA_LOG4J} \
     -jar $BALBOA_ARTIFACT $BALBOA_PORT'

--- a/balboa-service-jms/docker/Dockerfile
+++ b/balboa-service-jms/docker/Dockerfile
@@ -2,8 +2,7 @@ FROM socrata/java8
 
 # Forward the ZooKeeper and Cassandra Port.
 ENV BALBOA_PORT 2012
-ENV JMX_PORT 40506
-EXPOSE $BALBOA_PORT $JMX_PORT
+EXPOSE $BALBOA_PORT
 
 ### Environment Variables
 ENV BALBOA_ROOT /srv/balboa-service-jms

--- a/balboa-service-jms/docker/ship.d/run
+++ b/balboa-service-jms/docker/ship.d/run
@@ -9,10 +9,6 @@ set -ev
 exec sudo -u socrata java \
   -Xmx${JAVA_XMX} \
   -Xms${JAVA_XMX} \
-  -Dcom.sun.management.jmxremote.port=$JMX_PORT \
-  -Dcom.sun.management.jmxremote.ssl=false \
-  -Dcom.sun.management.jmxremote.authenticate=false \
-  -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT \
   -Dbalboa.config="$BALBOA_CONFIG" \
   -Dlog4j.configuration="$BALBOA_LOG4J" \
   -jar "$JAR" "$THREADS" "$ACTIVEMQ_CONNECTION_STRING" "$ACTIVEMQ_QUEUE"


### PR DESCRIPTION
The necessary JMX settings to correctly integrate with collectd metrics
collections are inherited from the socrata/runit-java8 image in the form
of JAVA_TOOL_OPTIONS. This change removes the balboa image specific
overrides.