### PR TITLE
Change service metric names.

### DIFF
--- a/balboa-http/src/main/scala/com/socrata/balboa/server/MainServlet.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/MainServlet.scala
@@ -6,19 +6,18 @@ import javax.servlet.http.HttpServletRequest
 import com.socrata.balboa.BuildInfo
 import com.socrata.balboa.metrics.data.{BalboaFastFailCheck, DataStoreFactory}
 import com.socrata.balboa.server.ResponseWithType.json
+import com.typesafe.scalalogging.StrictLogging
 import org.codehaus.jackson.map.annotate.JsonSerialize
 import org.codehaus.jackson.map.{ObjectMapper, SerializationConfig}
 import org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400
-import com.typesafe.scalalogging.StrictLogging
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra._
 import org.scalatra.json.JacksonJsonSupport
-import org.scalatra.metrics.MetricsSupport
 
 import scala.collection.JavaConverters._
 
 class MainServlet extends ScalatraServlet
-    with MetricsSupport
+    with SocrataMetricsSupport
     with ClientCounter
     with StrictLogging
     with RequestLogger

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/MetricsServlet.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/MetricsServlet.scala
@@ -12,13 +12,12 @@ import com.socrata.balboa.server.rest.Extractable
 import com.typesafe.scalalogging.StrictLogging
 import org.codehaus.jackson.map.annotate.JsonSerialize
 import org.codehaus.jackson.map.{ObjectMapper, SerializationConfig}
-import org.scalatra.metrics.MetricsSupport
 import org.scalatra.{ActionResult, NoContent, Ok}
 
 // scalastyle:off return
 
 class MetricsServlet extends JacksonJsonServlet
-    with MetricsSupport
+    with SocrataMetricsSupport
     with ClientCounter
     with RequestLogger
     with StrictLogging
@@ -69,10 +68,7 @@ class MetricsServlet extends JacksonJsonServlet
       return malformedDate(date).result
     })
 
-    // This timer name doesn't follow the recommended entity-verb-details pattern.
-    // It has been preserved for backwards compatibility until we know the full
-    // cost of changing the name.
-    timer("period queries")({
+    timer("metrics-get")({
       val iter = dataStore.find(entityId, period, range.start, range.end)
       var metrics = Metrics.summarize(iter)
 
@@ -114,10 +110,7 @@ class MetricsServlet extends JacksonJsonServlet
       return unacceptable.result
     })
 
-    // This timer name doesn't follow the recommended entity-verb-details pattern.
-    // It has been preserved for backwards compatibility until we know the full
-    // cost of changing the name.
-    timer("range queries")({
+    timer("metrics-get-range")({
       val iter = dataStore.find(entityId, startDate, endDate)
       var metrics = Metrics.summarize(iter)
 
@@ -166,7 +159,7 @@ class MetricsServlet extends JacksonJsonServlet
       return unacceptable.result
     })
 
-    timer("series queries")({
+    timer("metrics-get-series")({
       val body = renderJson(dataStore.slices(entityId, period, startDate, endDate)).getBytes(UTF_8)
       val resp = ResponseWithType(json, Ok(body))
       contentType = resp.contentType

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/SocrataMetricsSupport.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/SocrataMetricsSupport.scala
@@ -1,0 +1,39 @@
+package com.socrata.balboa.server
+
+import nl.grons.metrics.scala.MetricName
+import org.scalatra.metrics.MetricsSupport
+
+/**
+  * Wrapper around MetricsSupport that attempts to enforce certain conventions for collecting metrics within
+  * Socrata.
+  *
+  * <br>
+  *   Currently enforced conventions:
+  *    * Socrata currently uses collectd to collect application metrics exposed via JMX.  Metric names cannot be longer
+  *    the 63 characters.  When a metric name exceeds this length, the metric name is truncated at the end until it
+  *    meets the character limit requirement. This trait attempts to minimize the full metric name but does
+  *    not enforce that a metric name meet this requirement.  This trait does augment the base name of a metric to be
+  *    the <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html">SimpleName</a> of the
+  *    SocrataMetricsSupport implementing class.
+  *
+  */
+trait SocrataMetricsSupport extends MetricsSupport {
+
+  /**
+    * Sets the base name of the metric to nothing instead of using the class
+    * name. Using the class name for metric names makes the metrics fragile in
+    * relation to code refactoring. Any class or package renames would change
+    * the name of the metric, requiring that dashboards and alarms be updated
+    * to compensate. Making the metric names explicit gives the developer
+    * greater control, allowing metrics to be renamed, or not, depending on the
+    * actions being tracked.
+    * <br>
+    *   Example:
+    *   Rather then looking in Graphite for:
+    *     assetinventory->us-west-2->com.socrata.assetinventory.somepackage.TheClassName
+    *   You can look for:
+    *     assetinventory->us-west-2->metric_name
+    */
+  override final lazy val metricBaseName: MetricName = MetricName("")
+
+}


### PR DESCRIPTION
The names of timing metrics used for reporting the behavior of the
balboa-http service were preserved in their original format for
backwards compatibility. However, after spending much time
troubleshooting and trying to make metrics publishing actually work, I
can only conclude it never worked, and there is nothing to be backwards
compatible with, so I'm changing the metrics names to something more
useful.