### PR TITLE
Add a default uncaught exception handler

### DIFF
--- a/balboa-agent/src/main/scala/com/socrata/balboa/agent/BalboaAgent.scala
+++ b/balboa-agent/src/main/scala/com/socrata/balboa/agent/BalboaAgent.scala
@@ -24,6 +24,14 @@ import scala.concurrent.duration._
   * server.
   */
 object BalboaAgent extends App with Config with StrictLogging {
+  val ueh = new Thread.UncaughtExceptionHandler {
+      def uncaughtException(t: Thread,
+                            e: Throwable) {
+        logger.error("Uncaught exception in thread {}", t.getName, e)
+      }
+    }
+  Thread.setDefaultUncaughtExceptionHandler(ueh)
+
   logger info "Starting balboa-agent."
   private val scheduler = Executors.newScheduledThreadPool(1)
   private val dataDir = dataDirectory()


### PR DESCRIPTION
Best guess for the balboa-agent hangs are uncaught exceptions terminating
threads.  Rather than messing about with finally blocks, this just adds
a global handler to dump the logs.
