### PR TITLE
Hack commandline log-level setting into balboa-http

### DIFF
--- a/balboa-http/src/main/scala/ScalatraBootstrap.scala
+++ b/balboa-http/src/main/scala/ScalatraBootstrap.scala
@@ -1,7 +1,7 @@
 import javax.servlet.ServletContext
 
 import com.codahale.metrics.JmxReporter
-import com.socrata.balboa.server.{HealthCheckServlet, MainServlet, MetricsServlet}
+import com.socrata.balboa.server.{HealthCheckServlet, LogLevel, MainServlet, MetricsServlet}
 import com.typesafe.scalalogging.StrictLogging
 import org.scalatra.LifeCycle
 import org.scalatra.metrics.MetricsBootstrap
@@ -18,6 +18,8 @@ class ScalatraBootstrap extends LifeCycle with MetricsBootstrap with StrictLoggi
 
   override def init(context: ServletContext): Unit = {
     jmxReporter.start()
+
+    LogLevel.configureForMainClass(classOf[ScalatraBootstrap])
 
     logger.info("Assigning servlet handlers.")
     context.mount(new MainServlet, "/")

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/LogLevel.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/LogLevel.scala
@@ -1,0 +1,20 @@
+package com.socrata.balboa.server
+
+import java.util.Properties
+
+import org.apache.log4j.PropertyConfigurator
+
+object LogLevel {
+  def configureForMainClass[T](mainClass: Class[T]): Unit = {
+    val p = new Properties()
+    p.load(mainClass.getClassLoader().getResourceAsStream("config/config.properties"))
+
+    val logLevel = System.getProperty("loglevel")
+    if (null != logLevel && (logLevel.equals("DEBUG") || logLevel.equals("INFO") || logLevel.equals("ERROR"))) {
+      p.setProperty("log4j.logger.com.socrata.balboa", logLevel)
+    } else {
+      println("Unable to determine log level from environment, using default")
+    }
+    PropertyConfigurator.configure(p)
+  }
+}

--- a/balboa-http/src/main/scala/com/socrata/balboa/server/Main.scala
+++ b/balboa-http/src/main/scala/com/socrata/balboa/server/Main.scala
@@ -19,6 +19,8 @@ object Main extends App with StrictLogging {
     DefaultPort
   }
 
+  LogLevel.configureForMainClass(Main.getClass)
+
   val server = new Server(port)
   val context = new WebAppContext()
 


### PR DESCRIPTION
This is a stopgap solution to resolve EN-9166 that should
be replaced by the upcoming work to change the way balboa
is configured (possibly using typesafe config).