### PR TITLE
EN-10146: Add date and other stuff to balboa-service-jms logging

### DIFF
--- a/balboa-service-jms/src/main/resources/log4j.properties
+++ b/balboa-service-jms/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO,stdout
+log4j.rootLogger=WARN,stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.SimpleLayout
-log4j.category.org.apache=INFO, stdout
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%p] %d{MM-dd-yyyy HH:mm:ss} %c{1.} %M - %m%n


### PR DESCRIPTION
Logs now look something like...

```
[INFO] 11-07-2016 12:54:20 c.s.b.j.BalboaJms main - Receivers starting, awaiting messages.
[INFO] 11-07-2016 12:54:20 c.s.b.m.d.i.CassandraUtil$ initializeContext - Connecting to Cassandra servers 'localhost:9042'
[INFO] 11-07-2016 12:54:20 c.s.b.m.d.i.CassandraUtil$ initializeContext - Defaulting Cassandra client configuration to use all available datacenters
[INFO] 11-07-2016 12:54:20 c.s.b.m.d.i.CassandraUtil$ initializeContext - Using maximum size of '10' for Cassandra connection pool.
[INFO] 11-07-2016 12:54:20 c.s.b.m.d.i.CassandraUtil$ initializeContext - Setting Cassandra socket timeout to '120000'
[INFO] 11-07-2016 12:54:20 c.s.b.m.d.i.CassandraUtil$ initializeContext - Using keyspace 'Metrics2012'
[INFO] 11-07-2016 12:54:20 c.s.b.m.d.i.CassandraUtil$ initializeContext - Connecting to Cassandra on seed addresses: localhost/127.0.0.1:9042
[INFO] 11-07-2016 12:54:20 c.s.b.j.ActiveMQReceiver <init> - Starting server failover:tcp://localhost:8161?soTimeout=15000&soWriteTimeout=15000
[INFO] 11-07-2016 12:54:21 c.s.b.j.ActiveMQReceiver transportResumed - ActiveMQ transport resumed.
[WARN] 11-07-2016 12:54:21 o.a.a.t.f.FailoverTransport handleTransportFailure - Transport (tcp://localhost:8161?soTimeout=15000&soWriteTimeout=15000) failed , attempting to automatically rec
```

@jtoberon does that work for sumo?