### PR TITLE
EN-14710: Fix dangling file handlers

### DIFF
--- a/balboa-agent/src/it/bash/integration-tests
+++ b/balboa-agent/src/it/bash/integration-tests
@@ -5,10 +5,7 @@ BALBOA_AGENT_PID=0
 function cleanUp() {
     if [[ $BALBOA_AGENT_PID -gt 0 ]]; then
         echo "Stopping the balboa-agent."
-        # The balboa-agent is running with sbt, so balboa-agent itself is
-        # actually running as a child of sbt. Once you kill the child, the
-        # parent process will naturally exit.
-        kill $(ps -eo ppid,pid | grep "^$BALBOA_AGENT_PID" | cut -d' ' -f2)
+        kill $BALBOA_AGENT_PID
     fi
 
     # Remove the ActiveMQ queue created by these tests.
@@ -74,7 +71,7 @@ fi
 # service using sbt in the background to try to execute integration tests
 # faster.
 sbt balboa-agent/run >& $SERVICE_LOG &
-BALBOA_AGENT_PID=$!
+SBT_PID=$!
 
 echo -n "Waiting for balboa-agent to start."
 i=0
@@ -91,6 +88,10 @@ while ! grep "Connected to ActiveMQ broker" $SERVICE_LOG >& /dev/null ; do
 done
 echo
 echo "balboa-agent service is started."
+# The balboa-agent is running with sbt, so balboa-agent itself is
+# actually running as a child of sbt.
+export BALBOA_AGENT_PID="$(ps -eo ppid,pid | grep "^${SBT_PID}" | cut -d' ' -f2)"
+echo "Balboa agent PID = ${BALBOA_AGENT_PID}"
 
 # The integration tests will use these environment variables for configuration:
 #     METRIC_DIRECTORY

--- a/balboa-agent/src/it/resources/application.conf
+++ b/balboa-agent/src/it/resources/application.conf
@@ -10,5 +10,6 @@ com.socrata.balboa.agent {
     activemq_queue: ${?BALBOA_JMS_AMQ_QUEUE}
     metric_directory: /tmp/balboa-agent-integration-test-metrics
     metric_directory: ${?BALBOA_AGENT_DATA_DIR}
+    agent_pid: ${BALBOA_AGENT_PID}
   }
 }

--- a/balboa-agent/src/it/scala/com/socrata/balboa/agent/IntegrationTestConfig.scala
+++ b/balboa-agent/src/it/scala/com/socrata/balboa/agent/IntegrationTestConfig.scala
@@ -7,7 +7,8 @@ import com.typesafe.config.{Config, ConfigFactory}
 object IntegrationTestConfig {
   val conf: Config = ConfigFactory.load().getConfig("com.socrata.balboa.agent.it")
 
-  val metricDirectory = new File(conf.getString("metric_directory"))
-  val activemqServer = conf.getString("activemq_server")
-  val activemqQueue = conf.getString("activemq_queue")
+  val metricDirectory: File = new File(conf.getString("metric_directory"))
+  val activemqServer: String = conf.getString("activemq_server")
+  val activemqQueue: String = conf.getString("activemq_queue")
+  val agentPid: String = conf.getString("agent_pid")
 }

--- a/balboa-agent/src/test/scala/com/socrata/balboa/agent/MetricConsumerSpec.scala
+++ b/balboa-agent/src/test/scala/com/socrata/balboa/agent/MetricConsumerSpec.scala
@@ -165,7 +165,7 @@ class MetricConsumerSpec extends WordSpec with ShouldMatchers with MockitoSugar 
     }
     "the root file has corrupt files" should {
       "logs errors and emits no metrics" in new MockQueue {
-        private val tempDir = Files.createTempDirectory("metrics")
+        private val tempDir = Files.createTempDirectory("metrics-codec-spec")
         private val start = "ff"
         private val separator = "fe"
         private val timestamp = "31343834323636343534333034"


### PR DESCRIPTION
* Load metric files into memory for processing instead of using memory-mapped
  files.  Memory-mapped file handlers will not be fully closed until a
  garbage collection occurs.  Instead, we will just load the metric files
  into memory and process them there.
* Add integration test for open file descriptors
* Also refactor integration tests a bit