### PR TITLE
remove 2.10 scala crosscompilation target. several dependencies are n…

### DIFF
--- a/balboa-agent/project/build.properties
+++ b/balboa-agent/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@
 // all invocation paths, so needed to remain backwards compatible, the Jenkins
 // build jobs work yet a different way, and are invoked:
 //
-//     sbt 'set crossScalaVersions := List("2.10.6", "2.11.8")' "+balboa-client-dispatcher/compile"
+//     sbt 'set crossScalaVersions := List("2.11.8")' "+balboa-client-dispatcher/compile"
 //
 
 scalaVersion := "2.11.8"

--- a/project/BalboaClient.scala
+++ b/project/BalboaClient.scala
@@ -9,7 +9,7 @@ object BalboaClient {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings ++ Seq(
     libraryDependencies <++= scalaVersion {libraries(_)},
     parallelExecution in Test := false,
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    crossScalaVersions := Seq("2.11.8"),
     ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 2
   )
 

--- a/project/BalboaCommon.scala
+++ b/project/BalboaCommon.scala
@@ -7,7 +7,7 @@ object BalboaCommon {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings ++ Seq(
     libraryDependencies <++= scalaVersion {libraries(_)},
     sbtbuildinfo.BuildInfoKeys.buildInfoPackage := "com.socrata.balboa",
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    crossScalaVersions := Seq("2.11.8"),
     ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 0
   )
 

--- a/project/BalboaCore.scala
+++ b/project/BalboaCore.scala
@@ -6,7 +6,7 @@ import scoverage.ScoverageSbtPlugin
 object BalboaCore {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings ++ Seq(
     libraryDependencies <++= scalaVersion {libraries(_)} ,
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    crossScalaVersions := Seq("2.11.8"),
     ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 0
   )
 


### PR DESCRIPTION
…o longer available for 2.10 scala and keep this project from compiling properly

I could not find 2.10 versions of the following dependencies 
com.typesafe.scala-logging#scala-logging_2.10;3.4.0: not found
io.megam#newman_2.10;1.3.12: not found

the project compiles fine under 2.11.x. I removed the crosscompile directives for version 2.10.x