### PR TITLE
EN-36732: Avoid logging stacktrace line-by-line

### DIFF
--- a/balboa-service-jms/src/main/resources/log4.properties
+++ b/balboa-service-jms/src/main/resources/log4.properties
@@ -1,0 +1,6 @@
+log4j.rootLogger=INFO,stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%p] %d %c %M - %m%n
+log4j.category.org.apache=INFO,stdout
+


### PR DESCRIPTION
This is to help with Sumo being able to ingest these log lines without
putting each line of the stacktrace in its own log line.