### PR TITLE
EN-36770: Periodically kill balboa-service-jms

### DIFF
--- a/balboa-service-jms/docker/ship.d/run
+++ b/balboa-service-jms/docker/ship.d/run
@@ -2,7 +2,10 @@
 
 set -ev
 
-exec sudo -E -u socrata java \
+# 24 hours, in minutes, +/- 30 minutes
+timeout_minutes=$(shuf -i 1410-1470 -n 1)
+
+exec sudo -E -u socrata timeout "${timeout_minutes}"m java \
   -Xmx${JAVA_XMX} \
   -Xms${JAVA_XMX} \
   -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE_SIZE} \


### PR DESCRIPTION
Prior to this change, it is speculated that a long-running
balboa-service-jms instance could get into a state that would cause an
accumulation of messages in the Metrics2012 and Metrics2012.DLQ ActiveMQ
queues, eventually paging the on-call engineer and requiring manual
intervention to restart and scale the balboa-service-jms instances.

This change modifies the run script for balboa-service-jms' docker
container to automatically kill the main process, and thus the whole
container, approximately every 24 hours.  At this point Marathon will
replace the container with a fresh one, preventing any one container
from living longer than approximately 24 hours.