### PR TITLE
NO-JIRA: Fix broken integration test script

### DIFF
--- a/balboa-http/src/it/bash/integration-tests
+++ b/balboa-http/src/it/bash/integration-tests
@@ -95,7 +95,7 @@ function startServiceStack() {
     -v $(pwd)/${SCHEMA_DIR}:/balboa-schema \
     cassandra:2.1
 
-  dockerHost=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $DB_IMAGE_NAME)
+  dockerHost=$(docker inspect --format '{{ .NetworkSettings.Gateway }}' $DB_IMAGE_NAME)
   dbServerIp=$dockerHost
   dbPort=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "9042/tcp") 0).HostPort }}' $DB_IMAGE_NAME)
 

--- a/balboa-http/src/it/bash/integration-tests
+++ b/balboa-http/src/it/bash/integration-tests
@@ -71,25 +71,6 @@ function getAvailableServicePort() {
 }
 
 function startServiceStack() {
-  if uname -a | grep Darwin >& /dev/null ; then
-    # On a Mac, look for the IP address of the VM docker-machine is using to run
-    # Docker containers.
-    eval $(docker-machine env)
-    dockerHost=$(docker-machine ip)
-    if [[ ! $? -eq 0 ]]; then
-      echo "Could not get the IP address of an active docker-machine instance."
-      echo "Use 'docker-machine ls' to confirm there is an active host."
-      exit 1
-    fi
-  else
-    # On Linux, look for the IP address associated with the 'docker' interface.
-    dockerHost=$(/sbin/ifconfig docker0 | sed '/inet addr:/!d;s|.*inet addr:\([^ ]*\).*|\1|')
-    if [[ -z $dockerHost ]]; then
-      echo "Could not find a docker network interface. Is Docker installed?"
-      exit 1
-    fi
-  fi
-
   # Perform clean up activities under all circumstances (except kill -9) by
   # trapping the 'EXIT' pseudo-signal. Installing this signal handler means the
   # cleanUp function will be called whenever this script exits, even if
@@ -114,6 +95,7 @@ function startServiceStack() {
     -v $(pwd)/${SCHEMA_DIR}:/balboa-schema \
     cassandra:2.1
 
+  dockerHost=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $DB_IMAGE_NAME)
   dbServerIp=$dockerHost
   dbPort=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "9042/tcp") 0).HostPort }}' $DB_IMAGE_NAME)
 


### PR DESCRIPTION
Prior to this change, the balboa-http integration test script would fail
due to it being unable to determine the docker0 network interface IP
address. This appears to be due to changes in the output of ifconfig in
Ubuntu 18.04.

This change determines the IP address by using docker inspect with an
output formatter instead of parsing the output of ifconfig.