### PR TITLE
EN-35141: Upgraded balboa-http to ubuntu 18.04

### DIFF
--- a/balboa-http/docker/Dockerfile
+++ b/balboa-http/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/runit-java8
+FROM socrata/runit-java8-bionic
 
 # Forward the ZooKeeper and Cassandra Port.
 ENV BALBOA_PORT 2012


### PR DESCRIPTION
To test this, I followed the instructions in balboa-http/docker/readme.md.  The docker container ran just fine without error.